### PR TITLE
Ensure gloss table serialization round-trips

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ fn decompress_safe(mut data: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// Gloss table entries for precalculated compressed blocks.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct GlossEntry {
     pub seed: Vec<u8>,
     pub header: Header,
@@ -146,7 +146,7 @@ pub struct GlossEntry {
 }
 
 /// Gloss table supporting disk I/O and optional memory-mapped load.
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Debug)]
 pub struct GlossTable {
     pub entries: Vec<GlossEntry>,
 }

--- a/tests/gloss_table.rs
+++ b/tests/gloss_table.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+use std::fs;
+
+use inchworm::{GlossEntry, GlossTable, Header};
+
+#[test]
+fn save_load_roundtrip() {
+    // create a simple table with one entry
+    let entry = GlossEntry {
+        seed: vec![0xAA],
+        header: Header { seed_len: 0, nest_len: 0, arity: 0 },
+        decompressed: vec![1,2,3,4,5,6,7],
+    };
+    let table = GlossTable { entries: vec![entry.clone()] };
+
+    let mut path = std::env::temp_dir();
+    path.push("gloss_table_test.bin");
+    table.save(&path).unwrap();
+    let loaded = GlossTable::load(&path).unwrap();
+    fs::remove_file(&path).ok();
+
+    assert_eq!(table, loaded);
+}


### PR DESCRIPTION
## Summary
- derive `Debug` and `PartialEq` for `GlossEntry` and `GlossTable`
- add a unit test covering save/load round trips for `GlossTable`

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686a9bf032a08329935a45b5dd6e1250