### PR TITLE
Limit gloss unpack expansion

### DIFF
--- a/tests/gloss_table.rs
+++ b/tests/gloss_table.rs
@@ -1,7 +1,16 @@
 use std::path::PathBuf;
 use std::fs;
 
-use inchworm::{GlossEntry, GlossTable, Header};
+use inchworm::{
+    GlossEntry,
+    GlossTable,
+    Header,
+    encode_region,
+    Region,
+    BLOCK_SIZE,
+    decompress_with_limit,
+    decompress_region_with_limit,
+};
 
 #[test]
 fn save_load_roundtrip() {
@@ -20,4 +29,15 @@ fn save_load_roundtrip() {
     fs::remove_file(&path).ok();
 
     assert_eq!(table, loaded);
+}
+
+#[test]
+fn limit_enforced() {
+    let region = Region::Raw(vec![0; BLOCK_SIZE]);
+    let encoded = encode_region(&region);
+    assert!(decompress_with_limit(&encoded, BLOCK_SIZE).is_some());
+    assert!(decompress_with_limit(&encoded, BLOCK_SIZE - 1).is_none());
+
+    let long = Region::Raw(vec![0; 35]);
+    assert!(decompress_region_with_limit(&long, 32).is_none());
 }


### PR DESCRIPTION
## Summary
- add bounded-unpack helpers to ensure gloss entries never expand beyond 32 bytes
- apply size check during gloss table generation
- expose these helpers and add regression test

## Testing
- `cargo test --quiet` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686ad99a00dc8329a17d264876be2c40