### PR TITLE
Adjust header format

### DIFF
--- a/src/gloss.rs
+++ b/src/gloss.rs
@@ -37,7 +37,7 @@ impl GlossTable {
                 let seed_bytes = &seed_val.to_be_bytes()[8 - seed_len as usize..];
                 let digest = Sha256::digest(seed_bytes);
                 for len in 0..=digest.len() {
-                    if let Some(bytes) = decompress_with_limit(&digest[..len], 32) {
+                    if let Some(bytes) = decompress_with_limit(&digest[..len], 2 * 1024 * 1024) {
                         let blocks = bytes.len() / BLOCK_SIZE;
                         if bytes.len() % BLOCK_SIZE != 0 || !(2..=4).contains(&blocks) {
                             continue;
@@ -47,7 +47,7 @@ impl GlossTable {
                             nest_len: len as u32,
                             arity: blocks as u8 - 1,
                         };
-                        if let Some(out) = unpack_with_limit(seed_bytes, header, 32) {
+                        if let Some(out) = unpack_with_limit(seed_bytes, header, 2 * 1024 * 1024) {
                             entries.push(GlossEntry {
                                 seed: seed_bytes.to_vec(),
                                 header,

--- a/tests/gloss_table.rs
+++ b/tests/gloss_table.rs
@@ -17,7 +17,7 @@ fn save_load_roundtrip() {
     // create a simple table with one entry
     let entry = GlossEntry {
         seed: vec![0xAA],
-        header: Header { seed_len: 0, nest_len: 0, arity: 0 },
+        header: Header { seed_len: 0, nest_len: 0x1FFFFF, arity: 0 },
         decompressed: vec![1,2,3,4,5,6,7],
     };
     let table = GlossTable { entries: vec![entry.clone()] };

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -1,0 +1,12 @@
+use inchworm::Header;
+
+#[test]
+fn pack_unpack_roundtrip() {
+    let cases = [
+        Header { seed_len: 0, nest_len: 0, arity: 0 },
+        Header { seed_len: 1, nest_len: 0x1FFFFF, arity: 3 },
+    ];
+    for h in cases.iter() {
+        assert_eq!(Header::unpack(h.pack()), *h);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor Header packing bits to free up a flag
- limit seed lengths to at most two bytes
- support deeper nesting in gloss generation
- add helper APIs for bounded decompression
- test header packing/unpacking

## Testing
- `cargo test --quiet` *(fails: failed to download index)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b41a6a083299f713ea666455101