### PR TITLE
Add compress_block stub

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,0 +1,12 @@
+use crate::header::Header;
+
+/// Attempt to compress a block of data.
+///
+/// Returns the selected `Header` along with the number of bytes
+/// consumed if a compression opportunity is found. `None` indicates
+/// that the input should remain uncompressed.
+pub fn compress_block(_input: &[u8]) -> Option<(Header, usize)> {
+    // Compression logic to be implemented
+    None
+}
+


### PR DESCRIPTION
## Summary
- stub out `compress_block` in a new `compress.rs`

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c71aaf9708329ab130341166e23e6