### PR TITLE
Handle literal passthrough arities

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -7,6 +7,14 @@ pub struct Header {
     pub arity: usize,
 }
 
+impl Header {
+    /// Returns true if this header represents a literal passthrough block
+    /// rather than a compressed entry.
+    pub fn is_literal(&self) -> bool {
+        matches!(self.arity, 38 | 39 | 40)
+    }
+}
+
 /// Errors that can occur while decoding a header
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum HeaderError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,24 @@ pub fn decompress_with_limit(
         let (seed_idx, arity, bits) = decode_header(&data[offset..]).ok()?;
         let header = Header { seed_index: seed_idx, arity };
         offset += (bits + 7) / 8;
-        let region = Region::Compressed(Vec::new(), header);
-        let remaining = max_bytes.checked_sub(out.len())?;
-        let bytes = decompress_region_with_limit(&region, gloss, remaining)?;
-        out.extend_from_slice(&bytes);
+        if header.is_literal() {
+            let blocks = header.arity - 37;
+            let byte_count = blocks * BLOCK_SIZE;
+            if offset + byte_count > data.len() {
+                return None;
+            }
+            let remaining = max_bytes.checked_sub(out.len())?;
+            if byte_count > remaining {
+                return None;
+            }
+            out.extend_from_slice(&data[offset..offset + byte_count]);
+            offset += byte_count;
+        } else {
+            let region = Region::Compressed(Vec::new(), header);
+            let remaining = max_bytes.checked_sub(out.len())?;
+            let bytes = decompress_region_with_limit(&region, gloss, remaining)?;
+            out.extend_from_slice(&bytes);
+        }
     }
     Some(out)
 }

--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -1,4 +1,13 @@
-use inchworm::{GlossEntry, GlossTable, Header, Region, decompress_region_with_limit};
+use inchworm::{
+    GlossEntry,
+    GlossTable,
+    Header,
+    Region,
+    decompress_region_with_limit,
+    decompress_with_limit,
+    BLOCK_SIZE,
+    encode_header,
+};
 
 #[test]
 fn region_decompresses_from_gloss() {
@@ -23,4 +32,14 @@ fn region_decompress_limit_exceeded() {
     let table = GlossTable { entries: vec![entry] };
     let region = Region::Compressed(vec![0xBB], Header { seed_index: 0, arity: 1 });
     assert!(decompress_region_with_limit(&region, &table, 4).is_none());
+}
+
+#[test]
+fn passthrough_literals() {
+    let literals: Vec<u8> = (0u8..(BLOCK_SIZE as u8 * 2)).collect();
+    let mut data = encode_header(0, 39); // passthrough 2 blocks
+    data.extend_from_slice(&literals);
+    let table = GlossTable::default();
+    let out = decompress_with_limit(&data, &table, 100).unwrap();
+    assert_eq!(out, literals);
 }


### PR DESCRIPTION
## Summary
- support passthrough arity values 38..40
- copy literal data when a header is marked as passthrough
- add regression test for literal passthrough behavior

## Testing
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686de34a7d0c8329ad93422db40e79f0