### PR TITLE
Emit literal headers for uncompressed data

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -10,7 +10,7 @@ pub struct Header {
 impl Header {
     /// Returns true if this header represents a literal passthrough region.
     pub fn is_literal(&self) -> bool {
-        matches!(self.arity, 38 | 39 | 40)
+        matches!(self.arity, 37 | 38 | 39 | 40)
     }
 }
 

--- a/tests/compress_literals.rs
+++ b/tests/compress_literals.rs
@@ -1,0 +1,54 @@
+use inchworm::{
+    compress,
+    decompress_with_limit,
+    decode_header,
+    GlossTable,
+    Header,
+    BLOCK_SIZE,
+};
+
+#[test]
+fn compress_emits_literal_headers() {
+    let data: Vec<u8> = (0u8..50).collect();
+    let mut hashes = 0u64;
+    let out = compress(
+        &data,
+        1..=1,
+        None,
+        0,
+        &mut hashes,
+        false,
+        None,
+        0,
+        false,
+        None,
+        None,
+    );
+    let table = GlossTable::default();
+    let decompressed = decompress_with_limit(&out, &table, usize::MAX).unwrap();
+    assert_eq!(decompressed, data);
+
+    let mut offset = 0usize;
+    let mut idx = 0usize;
+    while offset < out.len() {
+        let (seed, arity, bits) = decode_header(&out[offset..]).unwrap();
+        let header = Header { seed_index: seed, arity };
+        offset += (bits + 7) / 8;
+        assert_eq!(header.seed_index, 0);
+        if header.arity == 40 {
+            assert_eq!(&out[offset..], &data[idx..]);
+            offset = out.len();
+            idx = data.len();
+            break;
+        } else {
+            assert!(header.arity >= 37 && header.arity <= 39);
+            let blocks = header.arity - 36;
+            let byte_count = blocks * BLOCK_SIZE;
+            assert_eq!(&out[offset..offset + byte_count], &data[idx..idx + byte_count]);
+            offset += byte_count;
+            idx += byte_count;
+        }
+    }
+    assert_eq!(idx, data.len());
+    assert_eq!(offset, out.len());
+}

--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -37,7 +37,7 @@ fn region_decompress_limit_exceeded() {
 #[test]
 fn passthrough_decompresses() {
     let table = GlossTable { entries: Vec::new() };
-    let header = encode_header(0, 38); // passthrough 1 block
+    let header = encode_header(0, 37); // passthrough 1 block
     let literal = vec![0x11; 1 * BLOCK_SIZE];
     let mut data = header.clone();
     data.extend_from_slice(&literal);
@@ -48,7 +48,7 @@ fn passthrough_decompresses() {
 #[test]
 fn passthrough_respects_limit() {
     let table = GlossTable { entries: Vec::new() };
-    let header = encode_header(0, 39); // passthrough 2 blocks
+    let header = encode_header(0, 38); // passthrough 2 blocks
     let literal = vec![0x22; 2 * BLOCK_SIZE];
     let mut data = header.clone();
     data.extend_from_slice(&literal);
@@ -58,7 +58,7 @@ fn passthrough_respects_limit() {
 #[test]
 fn passthrough_prefix_safe() {
     let table = GlossTable { entries: Vec::new() };
-    let header = encode_header(0, 40); // passthrough 3 blocks
+    let header = encode_header(0, 39); // passthrough 3 blocks
     let literal = vec![0x33; 3 * BLOCK_SIZE - 1]; // intentionally 1 byte short
     let mut data = header.clone();
     data.extend_from_slice(&literal);
@@ -68,7 +68,17 @@ fn passthrough_prefix_safe() {
 #[test]
 fn passthrough_literals_basic() {
     let literals: Vec<u8> = (0u8..(BLOCK_SIZE as u8 * 2)).collect();
-    let mut data = encode_header(0, 39); // passthrough 2 blocks
+    let mut data = encode_header(0, 38); // passthrough 2 blocks
+    data.extend_from_slice(&literals);
+    let table = GlossTable::default();
+    let out = decompress_with_limit(&data, &table, 100).unwrap();
+    assert_eq!(out, literals);
+}
+
+#[test]
+fn passthrough_final_tail() {
+    let literals: Vec<u8> = (0u8..5).collect();
+    let mut data = encode_header(0, 40); // final tail
     data.extend_from_slice(&literals);
     let table = GlossTable::default();
     let out = decompress_with_limit(&data, &table, 100).unwrap();


### PR DESCRIPTION
## Summary
- ensure literal passthrough headers are generated directly in `compress`
- support new literal arities in `Header` and `decompress_with_limit`
- update decompression tests for new arity scheme
- add test confirming compress() emits literal headers correctly

## Testing
- `cargo test --quiet` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686df6b812ec8329b447dcb545b2d9d0