### PR TITLE
Add compression roundtrip test

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,25 @@
+#[test]
+fn compression_roundtrip_identity() {
+    use inchworm::{compress, decompress, GlossTable};
+
+    let input: Vec<u8> = (0..100u8).collect();
+    let mut counter = 0u64;
+
+    let output = compress(
+        &input,
+        1..=2,
+        None,
+        1000,
+        &mut counter,
+        false,
+        None,
+        0,
+        false,
+        None,
+        None,
+    );
+
+    let gloss = GlossTable::default();
+    let reconstructed = decompress(&output, &gloss);
+    assert_eq!(input, reconstructed);
+}


### PR DESCRIPTION
## Summary
- add a roundtrip unit test ensuring compression followed by decompression
  yields the original data

## Testing
- `cargo test` *(fails: cannot download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686df88b9ee8832999f0f90c56f9eb07