### PR TITLE
Add mixed gloss passthrough test

### DIFF
--- a/tests/gloss_passthrough.rs
+++ b/tests/gloss_passthrough.rs
@@ -1,0 +1,28 @@
+#[test]
+fn mixed_gloss_and_passthrough() {
+    use inchworm::*;
+
+    let entry = GlossEntry {
+        seed: vec![0xDE],
+        decompressed: b"hello!!!".to_vec(),
+    };
+    let gloss = GlossTable { entries: vec![entry] };
+
+    let input = b"hello!!!abcxyz!".to_vec(); // "hello!!!" is glossed, rest is passthrough
+    let mut counter = 0;
+    let compressed = compress(
+        &input,
+        1..=2,
+        None,
+        1000,
+        &mut counter,
+        false,
+        Some(&gloss),
+        0,
+        false,
+        None,
+        None,
+    );
+    let output = decompress(&compressed, &gloss);
+    assert_eq!(input, output);
+}


### PR DESCRIPTION
## Summary
- add regression test ensuring compression works with partial gloss and passthrough data

## Testing
- `cargo test` *(fails: failed to fetch crates.io index)*

------
https://chatgpt.com/codex/tasks/task_e_686df89a1f848329a705bdcd073df5e5