### PR TITLE
Implement compression path cache

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,12 +1,78 @@
 use crate::header::Header;
+use crate::path::{CompressionPath, PathGloss};
+use crate::BLOCK_SIZE;
+use sha2::{Digest, Sha256};
 
 /// Attempt to compress a block of data.
 ///
 /// Returns the selected `Header` along with the number of bytes
 /// consumed if a compression opportunity is found. `None` indicates
 /// that the input should remain uncompressed.
-pub fn compress_block(_input: &[u8]) -> Option<(Header, usize)> {
-    // Compression logic to be implemented
-    None
+/// The provided `gloss` stores previously successful compression paths.
+/// `counter` is used to assign unique identifiers to new paths.
+pub fn compress_block(
+    input: &[u8],
+    gloss: &mut PathGloss,
+    counter: &mut u64,
+) -> Option<(Header, usize)> {
+    if input.len() < BLOCK_SIZE {
+        return None;
+    }
+
+    let span_hash: [u8; 32] = Sha256::digest(&input[..BLOCK_SIZE]).into();
+
+    if let Some((idx, path)) = gloss.match_span(&span_hash) {
+        if path.total_gain >= 2 * path.seeds.len() as u32 {
+            let mut matched_blocks = 0usize;
+            let mut matched = true;
+            for (step, seed) in path.seeds.iter().enumerate() {
+                let start = step * BLOCK_SIZE;
+                let end = start + seed.len();
+                if end > input.len() || input[start..end] != seed[..] {
+                    matched = false;
+                    if step >= 3 {
+                        break; // stop replay after 3 mismatched steps
+                    }
+                    break;
+                } else {
+                    matched_blocks += 1;
+                }
+            }
+            if matched && matched_blocks > 0 {
+                gloss.increment_replayed(idx);
+                let header = Header {
+                    seed_index: path.path_id as usize,
+                    arity: matched_blocks,
+                };
+                return Some((header, matched_blocks * BLOCK_SIZE));
+            }
+        }
+    }
+
+    let blocks = (input.len() / BLOCK_SIZE).min(3);
+    let consumed = blocks * BLOCK_SIZE;
+
+    if blocks >= 2 {
+        let mut seeds = Vec::new();
+        let mut hashes = Vec::new();
+        for i in 0..blocks {
+            let start = i * BLOCK_SIZE;
+            let end = start + BLOCK_SIZE;
+            let slice = &input[start..end];
+            seeds.push(slice.to_vec());
+            hashes.push(Sha256::digest(slice).into());
+        }
+        let path = CompressionPath {
+            path_id: *counter,
+            seeds,
+            span_hashes: hashes,
+            total_gain: consumed as u32,
+            replayed: 0,
+        };
+        *counter += 1;
+        gloss.add_path(path);
+    }
+
+    Some((Header { seed_index: 0, arity: blocks }, consumed))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,13 @@ mod bloom;
 mod gloss;
 mod header;
 mod sha_cache;
+mod path;
 
 pub use bloom::*;
 pub use gloss::*;
 pub use header::{Header, encode_header, decode_header, HeaderError};
 pub use sha_cache::*;
+pub use path::*;
 
 const BLOCK_SIZE: usize = 7;
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,78 @@
+use std::collections::{HashMap, VecDeque};
+
+#[derive(Clone)]
+pub struct CompressionPath {
+    pub path_id: u64,
+    pub seeds: Vec<Vec<u8>>, // Max 16
+    pub span_hashes: Vec<[u8; 32]>,
+    pub total_gain: u32,
+    pub replayed: u32,
+}
+
+pub struct PathGloss {
+    pub paths: VecDeque<CompressionPath>,
+    pub index: HashMap<[u8; 32], usize>,
+}
+
+impl PathGloss {
+    pub fn new() -> Self {
+        Self {
+            paths: VecDeque::new(),
+            index: HashMap::new(),
+        }
+    }
+
+    pub fn add_path(&mut self, mut path: CompressionPath) {
+        if path.seeds.len() > 16 {
+            path.seeds.truncate(16);
+        }
+        if 2 * path.total_gain < path.seeds.len() as u32 {
+            return; // skip low gain paths
+        }
+        self.paths.push_back(path);
+        self.rebuild_index();
+        if self.paths.len() > 100 {
+            let (idx, _) = self
+                .paths
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, p)| p.total_gain)
+                .unwrap();
+            self.remove_at(idx);
+        }
+    }
+
+    pub fn match_span(&self, hash: &[u8; 32]) -> Option<(usize, &CompressionPath)> {
+        self.index
+            .get(hash)
+            .and_then(|&idx| self.paths.get(idx).map(|p| (idx, p)))
+    }
+
+    pub fn increment_replayed(&mut self, idx: usize) {
+        if let Some(p) = self.paths.get_mut(idx) {
+            p.replayed += 1;
+        }
+    }
+
+    fn rebuild_index(&mut self) {
+        self.index.clear();
+        for (i, p) in self.paths.iter().enumerate() {
+            for h in &p.span_hashes {
+                self.index.insert(*h, i);
+            }
+        }
+    }
+
+    fn remove_at(&mut self, idx: usize) {
+        if idx >= self.paths.len() {
+            return;
+        }
+        let mut vec: Vec<_> = self.paths.drain(..).collect();
+        let removed = vec.remove(idx);
+        self.paths = vec.into();
+        for h in &removed.span_hashes {
+            self.index.remove(h);
+        }
+        self.rebuild_index();
+    }
+}


### PR DESCRIPTION
## Summary
- add `CompressionPath` and `PathGloss` in `path.rs`
- expose new module from the library
- update `compress_block` to store and replay compression paths

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686eafc84cf0832991611cb35b69da36