### PR TITLE
Implement belief cache for fallback seeds

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -10,3 +10,74 @@ pub fn compress_block(_input: &[u8]) -> Option<(Header, usize)> {
     None
 }
 
+/// Manage probabilistic fallback seeds using Bayesian scoring.
+pub struct FallbackSeeds {
+    pub map: crate::gloss::BeliefMap,
+    lambda: f64,
+    theta: f64,
+    block_len: usize,
+}
+
+impl FallbackSeeds {
+    pub fn new(lambda: f64, theta: f64, block_len: usize) -> Self {
+        Self {
+            map: crate::gloss::BeliefMap::new(10_000),
+            lambda,
+            theta,
+            block_len,
+        }
+    }
+
+    /// Should be called at start of a compression pass.
+    pub fn new_pass(&mut self) {
+        self.trim();
+    }
+
+    fn trim(&mut self) {
+        while self.map.len() > 10_000 {
+            if let Some((&key, _)) = self
+                .map
+                .iter()
+                .min_by(|a, b| {
+                    let ba = a.1.belief;
+                    let bb = b.1.belief;
+                    ba.partial_cmp(&bb)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.1.last_used.cmp(&b.1.last_used))
+                })
+            {
+                self.map.remove(&key);
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Record a failed compression attempt for `seed`.
+    pub fn record_failure(&mut self, digest: [u8; 32], seed: &[u8], evidence: f64, pass: u64) {
+        if seed.len() > 4 {
+            return;
+        }
+        if let Some(entry) = self.map.get_mut(&digest) {
+            let p = entry.belief;
+            let et = evidence;
+            entry.belief = (et * p) / (et * p + (1.0 - et) * (1.0 - p));
+            entry.last_used = pass;
+            entry.bundling_hits += 1;
+        } else {
+            let prior = (-self.lambda * ((seed.len() as isize - self.block_len as isize) as f64)).exp();
+            let s = crate::gloss::BeliefSeed {
+                seed: seed.to_vec(),
+                belief: prior,
+                last_used: pass,
+                bundling_hits: 1,
+                gloss_hits: 0,
+            };
+            if prior > self.theta {
+                self.map.insert(digest, s);
+                self.trim();
+            }
+        }
+    }
+}
+

--- a/src/gloss.rs
+++ b/src/gloss.rs
@@ -20,6 +20,54 @@ pub struct GlossTable {
     pub entries: Vec<GlossEntry>,
 }
 
+/// Entry tracked for probabilistic fallback seeding
+pub struct BeliefSeed {
+    pub seed: Vec<u8>,
+    pub belief: f64,
+    pub last_used: u64,
+    pub bundling_hits: u32,
+    pub gloss_hits: u32,
+}
+
+/// Simplistic LRU cache storing at most `capacity` entries.
+/// The caller is responsible for trimming when exceeding limits.
+pub struct LruCache<K: std::cmp::Eq + std::hash::Hash, V> {
+    capacity: usize,
+    map: std::collections::HashMap<K, V>,
+}
+
+impl<K: std::cmp::Eq + std::hash::Hash, V> LruCache<K, V> {
+    pub fn new(capacity: usize) -> Self {
+        Self { capacity, map: std::collections::HashMap::new() }
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.map.get_mut(key)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        if self.map.len() >= self.capacity {
+            // Caller should trim externally. Oldest removal is not automatic
+        }
+        self.map.insert(key, value);
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.map.remove(key)
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, K, V> {
+        self.map.iter()
+    }
+}
+
+/// Map of hashed seeds to belief entries.
+pub type BeliefMap = LruCache<[u8; 32], BeliefSeed>;
+
 impl GlossTable {
     /// Placeholder generator. In this trimmed example no automatic gloss table
     /// creation is performed.


### PR DESCRIPTION
## Summary
- add `BeliefSeed` with Bayesian belief tracking
- implement a tiny `LruCache` and type alias `BeliefMap`
- create `FallbackSeeds` manager in `compress.rs`

## Testing
- `cargo fmt -- --check` *(fails: `rustfmt` not installed)*
- `cargo test` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686eaffc8d4c83299189844909dc19ce