### PR TITLE
Add persistent seed logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ memmap2 = "0.5"
 [[bin]]
 name = "gloss_tool"
 path = "src/bin/gloss_tool.rs"
+
+[[bin]]
+name = "compressor"
+path = "src/bin/compressor.rs"

--- a/src/bin/compressor.rs
+++ b/src/bin/compressor.rs
@@ -1,0 +1,15 @@
+use inchworm::{log_seed, resume_seed_index};
+use sha2::{Digest, Sha256};
+
+fn main() {
+    let mut index = resume_seed_index();
+    for _ in 0..1000 {
+        let seed = index.to_le_bytes().to_vec();
+        let hash: [u8; 32] = Sha256::digest(&seed).into();
+        if let Err(e) = log_seed(index, seed, hash) {
+            eprintln!("failed to log seed {}: {e}", index);
+            break;
+        }
+        index += 1;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,14 @@ mod gloss;
 mod header;
 mod sha_cache;
 mod path;
+mod seed_logger;
 
 pub use bloom::*;
 pub use gloss::*;
 pub use header::{Header, encode_header, decode_header, HeaderError};
 pub use sha_cache::*;
 pub use path::*;
+pub use seed_logger::{resume_seed_index, log_seed, HashEntry};
 
 const BLOCK_SIZE: usize = 7;
 

--- a/src/seed_logger.rs
+++ b/src/seed_logger.rs
@@ -1,0 +1,41 @@
+use serde::{Serialize, Deserialize};
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufReader};
+use std::path::Path;
+
+#[derive(Serialize, Deserialize)]
+pub struct HashEntry {
+    pub seed_index: u64,
+    pub seed: Vec<u8>,
+    pub hash: [u8; 32],
+}
+
+pub fn resume_seed_index() -> u64 {
+    let path = Path::new("hash_table.bin");
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return 0,
+    };
+    let mut reader = BufReader::new(file);
+    let mut last = None;
+    loop {
+        match bincode::deserialize_from::<_, HashEntry>(&mut reader) {
+            Ok(entry) => last = Some(entry.seed_index),
+            Err(_) => break,
+        }
+    }
+    match last {
+        Some(idx) => idx + 1,
+        None => 0,
+    }
+}
+
+pub fn log_seed(seed_index: u64, seed: Vec<u8>, hash: [u8; 32]) -> io::Result<()> {
+    let entry = HashEntry { seed_index, seed, hash };
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("hash_table.bin")?;
+    bincode::serialize_into(&mut file, &entry)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+}


### PR DESCRIPTION
## Summary
- implement new `seed_logger` module
- export helpers in `lib.rs`
- provide `compressor` binary that writes hashes
- register new binary in Cargo manifest

## Testing
- `cargo test --quiet` *(fails: could not fetch index)*

------
https://chatgpt.com/codex/tasks/task_e_686ebad920f88329a0dc5e73605e0d98