### PR TITLE
Add hash precompute binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ path = "src/bin/gloss_tool.rs"
 [[bin]]
 name = "compressor"
 path = "src/bin/compressor.rs"
+
+[[bin]]
+name = "hash_precompute"
+path = "src/bin/hash_precompute.rs"

--- a/src/bin/hash_precompute.rs
+++ b/src/bin/hash_precompute.rs
@@ -1,0 +1,18 @@
+use sha2::{Sha256, Digest};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+fn main() -> std::io::Result<()> {
+    let file = File::create("seeds_1byte.txt")?;
+    let mut writer = BufWriter::new(file);
+
+    for seed in 0u8..=255u8 {
+        let mut hasher = Sha256::new();
+        hasher.update(&[seed]);
+        let result = hasher.finalize();
+        let hex_hash = hex::encode(result);
+        writeln!(writer, "{:02x}: {}", seed, hex_hash)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a `hash_precompute` binary for generating 1 byte seed hashes
- register the binary in `Cargo.toml`

## Testing
- `cargo run --bin hash_precompute` *(fails: could not fetch dependencies)*
- `cargo test` *(fails: could not fetch dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_686ec3bb4be48329b0e5912fb5aa3c12