### PR TITLE
Fix compression path helper methods and clean up

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -75,7 +75,7 @@ pub fn compress_block(
     let span_hash: [u8; 32] = Sha256::digest(&input[..BLOCK_SIZE]).into();
 
     if let Some((idx, path)) = gloss.match_span(&span_hash) {
-        if path.total_gain >= 2 * path.seeds.len() as u32 {
+        if path.total_gain >= 2 * path.seeds.len() as u64 {
             let mut matched_blocks = 0usize;
             let mut matched = true;
             for (step, seed) in path.seeds.iter().enumerate() {
@@ -94,7 +94,7 @@ pub fn compress_block(
             if matched && matched_blocks > 0 {
                 gloss.increment_replayed(idx);
                 let header = Header {
-                    seed_index: path.path_id as usize,
+                    seed_index: path.id as usize,
                     arity: matched_blocks,
                 };
                 return Some((header, matched_blocks * BLOCK_SIZE));
@@ -116,10 +116,10 @@ pub fn compress_block(
             hashes.push(Sha256::digest(slice).into());
         }
         let path = CompressionPath {
-            path_id: *counter,
+            id: *counter,
             seeds,
             span_hashes: hashes,
-            total_gain: consumed as u32,
+            total_gain: consumed as u64,
             replayed: 0,
         };
         *counter += 1;

--- a/src/gloss.rs
+++ b/src/gloss.rs
@@ -3,11 +3,6 @@ use memmap2::Mmap;
 use std::fs::File;
 use std::path::Path;
 
-use crate::{
-    Region,
-    Header,
-    BLOCK_SIZE,
-};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct GlossEntry {

--- a/src/header.rs
+++ b/src/header.rs
@@ -44,7 +44,7 @@ pub fn decode_header(input: &[u8]) -> Result<(usize, usize, usize), HeaderError>
 
 // ---- Internal utilities ----
 
-fn encode_vql(mut value: usize, out: &mut Vec<bool>) {
+fn encode_vql(value: usize, out: &mut Vec<bool>) {
     let mut width = 1usize;
     let mut n = 0usize;
     while value >= (1usize << width) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-use std::ops::RangeInclusive;
-use std::time::Instant;
-
 mod bloom;
 mod compress;
 mod gloss;

--- a/src/path.rs
+++ b/src/path.rs
@@ -97,6 +97,17 @@ impl PathGloss {
         self.index.get(hash).and_then(|&i| self.paths.get(i))
     }
 
+    pub fn match_span(&self, hash: &[u8; 32]) -> Option<(usize, &CompressionPath)> {
+        self.index
+            .get(hash)
+            .and_then(|&i| self.paths.get(i).map(|p| (i, p)))
+    }
+
+    pub fn add_path(&mut self, path: CompressionPath) {
+        self.paths.push_back(path);
+        self.rebuild_index();
+    }
+
     pub fn increment_replayed(&mut self, idx: usize) {
         if let Some(p) = self.paths.get_mut(idx) {
             p.replayed += 1;

--- a/src/sha_cache.rs
+++ b/src/sha_cache.rs
@@ -39,9 +39,10 @@ impl ShaCache {
     }
 
     pub fn get_or_compute(&mut self, seed: &[u8]) -> [u8; 32] {
-        if let Some(value) = self.map.get(seed) {
+        let found = self.map.get(seed).cloned();
+        if let Some(value) = found {
             self.touch(seed);
-            *value
+            value
         } else {
             let digest = Sha256::digest(seed);
             let arr: [u8; 32] = digest.into();


### PR DESCRIPTION
## Summary
- implement `match_span` and `add_path` on `PathGloss`
- fix compression block to use new methods and correct field names
- adjust types in `compress.rs`
- fix borrow checker issue in `ShaCache`
- remove unused `mut` parameter in `encode_vql`
- trim unused imports

## Testing
- `cargo check` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ec68e04c083298bd381d11ba12de6