### PR TITLE
Fix borrow conflict in compress_block

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -93,9 +93,10 @@ pub fn compress_block(
                 }
             }
             if matched && matched_blocks > 0 {
+                let path_id = path.id;
                 gloss.increment_replayed(idx);
                 let header = Header {
-                    seed_index: path.id as usize,
+                    seed_index: path_id as usize,
                     arity: matched_blocks,
                 };
                 return Some((header, matched_blocks * BLOCK_SIZE));


### PR DESCRIPTION
## Summary
- fix mutable/immutable borrow in `compress_block`

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ecdcbaa308329a846900b88f754dc