### PR TITLE
Fix compressor log_seed call

### DIFF
--- a/src/bin/compressor.rs
+++ b/src/bin/compressor.rs
@@ -6,7 +6,7 @@ fn main() {
     for _ in 0..1000 {
         let seed = index.to_le_bytes().to_vec();
         let hash: [u8; 32] = Sha256::digest(&seed).into();
-        if let Err(e) = log_seed(index, seed, hash) {
+        if let Err(e) = log_seed(index, hash) {
             eprintln!("failed to log seed {}: {e}", index);
             break;
         }


### PR DESCRIPTION
## Summary
- correct argument list for `log_seed` in `compressor.rs`

## Testing
- `cargo test` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_686ecfef5a7c8329b82a3055b1930379