### PR TITLE
Expose block size constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use sha_cache::*;
 pub use path::*;
 pub use seed_logger::{resume_seed_index, log_seed, HashEntry};
 
-const BLOCK_SIZE: usize = 7;
+pub const BLOCK_SIZE: usize = 7;
 
 pub fn print_compression_status(original: usize, compressed: usize) {
     let ratio = 100.0 * (1.0 - compressed as f64 / original as f64);


### PR DESCRIPTION
## Summary
- make `BLOCK_SIZE` public so it can be imported by other crates and binaries

## Testing
- `cargo test --quiet` *(fails: failed to download index from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686ed010d6c083298da79c149ce68954