### PR TITLE
Fix hash precompute compile errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bincode = "1"
 serde = { version = "1", features = ["derive"] }
 memmap2 = "0.5"
 thiserror = "2.0.12"
+bytemuck = "1"
 
 
 [[bin]]

--- a/src/bin/hash_precompute.rs
+++ b/src/bin/hash_precompute.rs
@@ -1,5 +1,5 @@
-use inchworm::G;
-use sha2::{Digest, Sha256};
+use bytemuck;
+use sha2::Sha256;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
@@ -29,14 +29,14 @@ fn main() -> std::io::Result<()> {
                 _ => unreachable!(),
             };
 
-            // Use G(seed) from inchworm
-            let out = G(&seed);
+            // Compute SHA-256 of the seed
+            let out: [u8; 32] = <Sha256 as sha2::digest::Digest>::digest(&seed).into();
             let mut padded_seed = [0u8; 3];
             padded_seed[..len].copy_from_slice(&seed);
 
             let entry = HashEntry {
                 hash: out,
-                seed_len: len,
+                seed_len: len as u8,
                 seed: padded_seed,
             };
 


### PR DESCRIPTION
## Summary
- update hash_precompute imports
- compute SHA-256 for seeds and cast seed length
- add bytemuck dependency

## Testing
- `cargo check --locked --offline` *(fails: no matching package named `bincode` found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecffd18ac8329877aeb66299535a6