### PR TITLE
Fix decompress call with gloss table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,8 @@ fn main() {
             }
         }
         "d" => {
-            let out = decompress(&data);
+            let gloss = gloss.unwrap_or_default();
+            let out = decompress(&data, &gloss);
             fs::write(&args[3], out).expect("failed to write output");
         }
         mode => eprintln!("Unknown mode: {}", mode),


### PR DESCRIPTION
## Summary
- pass the gloss table to the `decompress` call in `main.rs`

## Testing
- `cargo test` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_686ed0260bb08329afe28b1f564c6f54