### PR TITLE
Fix bytes_of for hash precompute

### DIFF
--- a/src/bin/hash_precompute.rs
+++ b/src/bin/hash_precompute.rs
@@ -1,11 +1,11 @@
-use bytemuck;
+use bytemuck::{Pod, Zeroable};
 use sha2::Sha256;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
 /// Entry written to the binary hash table file.
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Pod, Zeroable)]
 struct HashEntry {
     hash: [u8; 32],
     seed_len: u8,


### PR DESCRIPTION
## Summary
- mark `HashEntry` in `hash_precompute` as `Pod` and `Zeroable`
- import required traits for `bytemuck`

## Testing
- `cargo test` *(fails: failed to download crates from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686ed1b5c7208329b39b468eb197637d