### PR TITLE
Use bincode serialization in hash precompute tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +76,6 @@ name = "inchworm"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "bytemuck",
  "hex",
  "memmap2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ bincode = "1"
 serde = { version = "1", features = ["derive"] }
 memmap2 = "0.5"
 thiserror = "2.0.12"
-bytemuck = "1"
 
 
 [[bin]]


### PR DESCRIPTION
## Summary
- serialize hash entries with `bincode` and derive `Serialize`
- drop the `bytemuck` dependency
- clean up SHA-256 digest usage

## Testing
- `cargo test --offline --quiet` *(fails: no matching package named `hex` found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed3e68a8083298ee156ef4cc649db