### PR TITLE
Add Bayesian fields to GlossEntry

### DIFF
--- a/src/gloss.rs
+++ b/src/gloss.rs
@@ -4,10 +4,21 @@ use std::fs::File;
 use std::path::Path;
 
 
-#[derive(Serialize, Deserialize, Clone)]
+/// Entry describing a precomputed gloss string.
+///
+/// `score` tracks the Bayesian belief associated with this entry and `pass`
+/// optionally records the discovery pass during table generation.  These
+/// fields are currently unused by the simplified library but are preserved so
+/// that future pruning or visualisation tooling can make use of them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlossEntry {
     pub seed: Vec<u8>,
     pub decompressed: Vec<u8>,
+
+    /// Bayesian posterior belief `P(F | E)` for this entry.
+    pub score: f64,
+    /// Optional discovery pass number.
+    pub pass: usize,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -13,8 +13,9 @@ use inchworm::{
 fn region_decompresses_from_gloss() {
     let entry = GlossEntry {
         seed: vec![0xAA],
-        header: Header { seed_index: 0, arity: 1 },
         decompressed: b"hello!!!".to_vec(),
+        score: 0.0,
+        pass: 0,
     };
     let table = GlossTable { entries: vec![entry.clone()] };
     let region = Region::Compressed(vec![0xAA], Header { seed_index: 0, arity: 1 });
@@ -26,8 +27,9 @@ fn region_decompresses_from_gloss() {
 fn region_decompress_limit_exceeded() {
     let entry = GlossEntry {
         seed: vec![0xBB],
-        header: Header { seed_index: 0, arity: 1 },
         decompressed: vec![1,2,3,4,5],
+        score: 0.0,
+        pass: 0,
     };
     let table = GlossTable { entries: vec![entry] };
     let region = Region::Compressed(vec![0xBB], Header { seed_index: 0, arity: 1 });

--- a/tests/gloss_passthrough.rs
+++ b/tests/gloss_passthrough.rs
@@ -5,6 +5,8 @@ fn mixed_gloss_and_passthrough() {
     let entry = GlossEntry {
         seed: vec![0xDE],
         decompressed: b"hello!!!".to_vec(),
+        score: 0.0,
+        pass: 0,
     };
     let gloss = GlossTable { entries: vec![entry] };
 


### PR DESCRIPTION
## Summary
- include `score` and `pass` in `GlossEntry`
- update unit tests to construct `GlossEntry` with the new metadata

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f12088a948329843ac7a2cf19f8ff