### PR TITLE
Add fallback seed CSV logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bincode = "1"
 serde = { version = "1", features = ["derive"] }
 memmap2 = "0.5"
 thiserror = "2.0.12"
+csv = "1"
 
 
 [[bin]]

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -4,6 +4,8 @@ use std::time::Instant;
 use crate::BLOCK_SIZE;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
+use csv;
+use hex;
 
 /// In-memory table storing truncated SHA-256 prefixes.
 ///
@@ -201,4 +203,24 @@ impl FallbackSeeds {
             }
         }
     }
+}
+
+/// Write the current belief map to a CSV file for debugging.
+pub fn dump_gloss_to_csv(map: &crate::gloss::BeliefMap, path: &str) -> std::io::Result<()> {
+    let mut wtr = csv::Writer::from_path(path)?;
+    wtr.write_record(&["SeedHex", "Score", "Pass", "BundlingHits", "GlossHits"])?;
+
+    for entry in map.iter().map(|(_, e)| e) {
+        let seed_hex = hex::encode(&entry.seed);
+        wtr.write_record(&[
+            seed_hex,
+            format!("{:.4}", entry.belief),
+            entry.last_used.to_string(),
+            entry.bundling_hits.to_string(),
+            entry.gloss_hits.to_string(),
+        ])?;
+    }
+
+    wtr.flush()?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add `csv` crate for debug output
- expose `dump_gloss_to_csv` to export belief seed scores

## Testing
- `cargo check` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686f122aa4b88329b3e2e1fb527af0be