### PR TITLE
Add gloss CSV dump tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bincode = "1"
 serde = { version = "1", features = ["derive"] }
 memmap2 = "0.5"
 thiserror = "2.0.12"
+csv = "1"
 
 
 [[bin]]
@@ -24,3 +25,7 @@ path = "src/bin/compressor.rs"
 [[bin]]
 name = "hash_precompute"
 path = "src/bin/hash_precompute.rs"
+
+[[bin]]
+name = "gloss_debug_dump"
+path = "src/bin/gloss_debug_dump.rs"

--- a/src/bin/gloss_debug_dump.rs
+++ b/src/bin/gloss_debug_dump.rs
@@ -1,0 +1,33 @@
+use inchworm::GlossTable;
+use std::env;
+
+pub fn dump_gloss_to_csv(gloss: &GlossTable, path: &str) -> std::io::Result<()> {
+    let mut wtr = csv::Writer::from_path(path)?;
+    wtr.write_record(&["Index", "SeedHex", "DataHex"])?;
+    for (idx, entry) in gloss.entries.iter().enumerate() {
+        let seed_hex = hex::encode(&entry.seed);
+        let data_hex = hex::encode(&entry.decompressed);
+        wtr.write_record(&[idx.to_string(), seed_hex, data_hex])?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: {} <gloss.bin> <output.csv>", args[0]);
+        std::process::exit(1);
+    }
+    let table = match GlossTable::load(&args[1]) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Failed to load gloss table: {e}");
+            std::process::exit(1);
+        }
+    };
+    if let Err(e) = dump_gloss_to_csv(&table, &args[2]) {
+        eprintln!("Failed to write CSV: {e}");
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add `gloss_debug_dump` binary to export gloss contents to CSV
- include csv crate dependency

## Testing
- `cargo test` *(fails: Failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686f12b538d88329aab9d9595b96dad2