### PR TITLE
Add gloss pruning hook

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -188,6 +188,7 @@ impl FallbackSeeds {
     /// Should be called at start of a compression pass.
     pub fn new_pass(&mut self) {
         self.trim();
+        crate::gloss_prune_hook::run(&mut self.map);
     }
 
     fn trim(&mut self) {

--- a/src/gloss.rs
+++ b/src/gloss.rs
@@ -63,6 +63,41 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> LruCache<K, V> {
 /// Map of hashed seeds to belief entries.
 pub type BeliefMap = LruCache<[u8; 32], BeliefSeed>;
 
+impl BeliefMap {
+    /// Prune entries with belief below `min_score` and ensure the map does not
+    /// exceed `max_entries`. When trimming due to size, the lowest belief
+    /// entries are removed first and ties are broken by `last_used`.
+    pub fn prune_low_score_entries(&mut self, min_score: f64, max_entries: usize) {
+        let to_remove: Vec<[u8; 32]> = self
+            .map
+            .iter()
+            .filter(|(_, v)| v.belief < min_score)
+            .map(|(k, _)| *k)
+            .collect();
+        for k in to_remove {
+            self.map.remove(&k);
+        }
+
+        while self.map.len() > max_entries {
+            if let Some((&key, _)) = self
+                .map
+                .iter()
+                .min_by(|a, b| {
+                    let ba = a.1.belief;
+                    let bb = b.1.belief;
+                    ba.partial_cmp(&bb)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.1.last_used.cmp(&b.1.last_used))
+                })
+            {
+                self.map.remove(&key);
+            } else {
+                break;
+            }
+        }
+    }
+}
+
 impl GlossTable {
     /// Placeholder generator. In this trimmed example no automatic gloss table
     /// creation is performed.

--- a/src/gloss_prune_hook.rs
+++ b/src/gloss_prune_hook.rs
@@ -1,0 +1,8 @@
+use crate::gloss::BeliefMap;
+
+/// Invoke gloss pruning at the end of a compression pass.
+pub fn run(gloss: &mut BeliefMap) {
+    let max_gloss_entries = 10_000_000; // fits in 1GB
+    let min_belief_score = 0.10;
+    gloss.prune_low_score_entries(min_belief_score, max_gloss_entries);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod header;
 mod sha_cache;
 mod path;
 mod seed_logger;
+mod gloss_prune_hook;
 
 pub use bloom::*;
 pub use compress::TruncHashTable;
@@ -13,6 +14,7 @@ pub use header::{Header, encode_header, decode_header, HeaderError};
 pub use sha_cache::*;
 pub use path::*;
 pub use seed_logger::{resume_seed_index, log_seed, HashEntry};
+pub use gloss_prune_hook::run as gloss_prune_hook;
 
 pub const BLOCK_SIZE: usize = 7;
 


### PR DESCRIPTION
## Summary
- implement `BeliefMap::prune_low_score_entries`
- expose a new `gloss_prune_hook` module with a helper to run pruning
- call pruning from `FallbackSeeds::new_pass`

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686f12a86d688329bd77a5aa59504363