### PR TITLE
Add belief map JSON export

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -6,6 +6,9 @@ use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use csv;
 use hex;
+use std::fs::File;
+use std::io::Write;
+use serde_json;
 
 /// In-memory table storing truncated SHA-256 prefixes.
 ///
@@ -258,5 +261,14 @@ pub fn dump_gloss_to_csv(map: &crate::gloss::BeliefMap, path: &str) -> std::io::
     }
 
     wtr.flush()?;
+    Ok(())
+}
+
+/// Write the current belief map to a JSON file for debugging.
+pub fn dump_beliefmap_json(map: &crate::gloss::BeliefMap, path: &str) -> std::io::Result<()> {
+    let entries: Vec<_> = map.iter().map(|(_, e)| e).collect();
+    let json = serde_json::to_string_pretty(&entries)?;
+    let mut file = File::create(path)?;
+    file.write_all(json.as_bytes())?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- expose `dump_beliefmap_json` to save `BeliefMap` as JSON

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686f16f95f508329bf8069a1f7209f85