### PR TITLE
Update block size constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use live_window::LiveStats;
 pub use live_window::print_window;
 pub use stats::Stats;
 
-pub const BLOCK_SIZE: usize = 7;
+pub const BLOCK_SIZE: usize = 3;
 
 pub fn print_compression_status(original: usize, compressed: usize) {
     let ratio = 100.0 * (1.0 - compressed as f64 / original as f64);


### PR DESCRIPTION
## Summary
- set `BLOCK_SIZE` constant in `lib.rs` to 3 bytes

## Testing
- `cargo test --quiet` *(fails: could not compile `inchworm` due to previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f2a7b80048329989f82b45c4605f0