### PR TITLE
Add multi-pass compression example

### DIFF
--- a/src/bin/multi_pass.rs
+++ b/src/bin/multi_pass.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn main() {
+    for i in 1..=10 {
+        let output = format!("kolyma_pass_{}.inchworm", i);
+        let status = Command::new("cargo")
+            .args([
+                "run",
+                "--release",
+                "--bin",
+                "compressor",
+                "c",
+                "kolyma.pdf",
+                &output,
+                "--status",
+                "--json",
+                "--gloss",
+                "gloss.bin",
+            ])
+            .status()
+            .expect("Pass compression failed");
+        if !status.success() {
+            eprintln!("Compression pass {} failed", i);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- revise `multi_pass` example to match user instructions

## Testing
- `cargo test --quiet` *(fails: out of range hex escape and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f27a685b4832986fcf6074af4b431