### PR TITLE
Implement block splitting helper

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -17,6 +17,47 @@ use std::collections::HashMap;
 /// BlockTable groups blocks by their bit length
 pub type BlockTable = HashMap<usize, Vec<Block>>;
 
+/// Split raw input into fixed-sized blocks measured in bits.
+///
+/// Each returned [`Block`] will have `bit_length` equal to `block_size_bits`
+/// except for the final block which may be shorter when the input length is not
+/// perfectly divisible by the requested block size. The raw byte data of each
+/// block is stored directly without any bit-level slicing or padding.
+pub fn split_into_blocks(input: &[u8], block_size_bits: usize) -> Vec<Block> {
+    assert!(block_size_bits > 0, "block size must be non-zero");
+
+    // Number of whole bytes that contain the requested number of bits. We round
+    // up so blocks always contain enough data even when not byte aligned.
+    let block_size_bytes = (block_size_bits + 7) / 8;
+
+    let mut blocks = Vec::new();
+    let mut offset = 0usize;
+    let mut index = 0usize;
+
+    while offset < input.len() {
+        let end = (offset + block_size_bytes).min(input.len());
+        let slice = &input[offset..end];
+        let bits = if end - offset == block_size_bytes {
+            block_size_bits
+        } else {
+            (end - offset) * 8
+        };
+
+        blocks.push(Block {
+            global_index: index,
+            bit_length: bits,
+            data: slice.to_vec(),
+            arity: None,
+            seed_index: None,
+        });
+
+        offset += block_size_bytes;
+        index += 1;
+    }
+
+    blocks
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -32,5 +73,29 @@ mod tests {
         };
         table.entry(block.bit_length).or_default().push(block.clone());
         assert_eq!(table.get(&8).unwrap()[0].global_index, 0);
+    }
+
+    #[test]
+    fn split_basic() {
+        let input = vec![1u8, 2, 3, 4, 5];
+        let blocks = split_into_blocks(&input, 16);
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(blocks[0].global_index, 0);
+        assert_eq!(blocks[0].bit_length, 16);
+        assert_eq!(blocks[0].data, vec![1u8, 2]);
+        assert_eq!(blocks[1].global_index, 1);
+        assert_eq!(blocks[1].bit_length, 16);
+        assert_eq!(blocks[1].data, vec![3u8, 4]);
+        assert_eq!(blocks[2].global_index, 2);
+        assert_eq!(blocks[2].bit_length, 8);
+        assert_eq!(blocks[2].data, vec![5u8]);
+    }
+
+    #[test]
+    fn split_exact() {
+        let input = vec![1u8, 2, 3, 4];
+        let blocks = split_into_blocks(&input, 16);
+        assert_eq!(blocks.len(), 2);
+        assert!(blocks.iter().all(|b| b.bit_length == 16));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use seed_logger::{resume_seed_index, log_seed, HashEntry};
 pub use gloss_prune_hook::run as gloss_prune_hook;
 pub use live_window::{LiveStats, print_window};
 pub use stats::Stats;
-pub use block::{Block, BlockTable};
+pub use block::{Block, BlockTable, split_into_blocks};
 
 use sha2::Digest;
 


### PR DESCRIPTION
## Summary
- add a helper `split_into_blocks` that divides raw input into `Block`s
- export the new function from the library
- provide basic unit tests for the splitting logic

## Testing
- `cargo test` *(fails: unresolved imports and missing functions)*

------
https://chatgpt.com/codex/tasks/task_e_687321aec3f48329b7580f2c86ea6bdd