### PR TITLE
Add block grouping helper

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -17,6 +17,19 @@ use std::collections::HashMap;
 /// BlockTable groups blocks by their bit length
 pub type BlockTable = HashMap<usize, Vec<Block>>;
 
+/// Given a flat list of [`Block`]s, return a [`BlockTable`]
+/// where blocks are grouped by their bit length.
+///
+/// This is primarily used when simulating the compression pipeline
+/// after splitting raw input into blocks.
+pub fn group_by_bit_length(blocks: Vec<Block>) -> BlockTable {
+    let mut table: BlockTable = HashMap::new();
+    for block in blocks {
+        table.entry(block.bit_length).or_default().push(block);
+    }
+    table
+}
+
 /// Split raw input into fixed-sized blocks measured in bits.
 ///
 /// Each returned [`Block`] will have `bit_length` equal to `block_size_bits`
@@ -71,7 +84,10 @@ mod tests {
             arity: None,
             seed_index: None,
         };
-        table.entry(block.bit_length).or_default().push(block.clone());
+        table
+            .entry(block.bit_length)
+            .or_default()
+            .push(block.clone());
         assert_eq!(table.get(&8).unwrap()[0].global_index, 0);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use seed_logger::{resume_seed_index, log_seed, HashEntry};
 pub use gloss_prune_hook::run as gloss_prune_hook;
 pub use live_window::{LiveStats, print_window};
 pub use stats::Stats;
-pub use block::{Block, BlockTable, split_into_blocks};
+pub use block::{Block, BlockTable, split_into_blocks, group_by_bit_length};
 
 use sha2::Digest;
 


### PR DESCRIPTION
## Summary
- group blocks by bit length
- export the helper from the library

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_687335973c288329857ae5969a0c50b3