### PR TITLE
Add block summary CLI and group_by_bit_length

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ path = "src/bin/gloss_by_pass_dump.rs"
 [[bin]]
 name = "seed_table"
 path = "src/bin/seed_table.rs"
+
+[[bin]]
+name = "block_summary"
+path = "src/bin/block_summary.rs"

--- a/src/bin/block_summary.rs
+++ b/src/bin/block_summary.rs
@@ -1,0 +1,21 @@
+use inchworm::{split_into_blocks, group_by_bit_length};
+use std::{env, fs};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: {} <input_file> <block_size_bits>", args[0]);
+        std::process::exit(1);
+    }
+
+    let path = &args[1];
+    let block_size: usize = args[2].parse().expect("Invalid block size");
+
+    let bytes = fs::read(path).expect("Failed to read input file");
+    let blocks = split_into_blocks(&bytes, block_size);
+    let table = group_by_bit_length(blocks);
+
+    for (bit_length, group) in table.iter() {
+        println!("{}-bit blocks: {}", bit_length, group.len());
+    }
+}

--- a/src/block.rs
+++ b/src/block.rs
@@ -58,6 +58,15 @@ pub fn split_into_blocks(input: &[u8], block_size_bits: usize) -> Vec<Block> {
     blocks
 }
 
+/// Group blocks by their bit length into a [`BlockTable`].
+pub fn group_by_bit_length(blocks: Vec<Block>) -> BlockTable {
+    let mut table: BlockTable = HashMap::new();
+    for block in blocks {
+        table.entry(block.bit_length).or_default().push(block);
+    }
+    table
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +106,17 @@ mod tests {
         let blocks = split_into_blocks(&input, 16);
         assert_eq!(blocks.len(), 2);
         assert!(blocks.iter().all(|b| b.bit_length == 16));
+    }
+
+    #[test]
+    fn group_blocks() {
+        let blocks = vec![
+            Block { global_index: 0, bit_length: 8, data: vec![0], arity: None, seed_index: None },
+            Block { global_index: 1, bit_length: 16, data: vec![1, 2], arity: None, seed_index: None },
+            Block { global_index: 2, bit_length: 8, data: vec![3], arity: None, seed_index: None },
+        ];
+        let table = group_by_bit_length(blocks);
+        assert_eq!(table.get(&8).unwrap().len(), 2);
+        assert_eq!(table.get(&16).unwrap().len(), 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use seed_logger::{resume_seed_index, log_seed, HashEntry};
 pub use gloss_prune_hook::run as gloss_prune_hook;
 pub use live_window::{LiveStats, print_window};
 pub use stats::Stats;
-pub use block::{Block, BlockTable, split_into_blocks};
+pub use block::{Block, BlockTable, split_into_blocks, group_by_bit_length};
 
 use sha2::Digest;
 


### PR DESCRIPTION
## Summary
- expose `group_by_bit_length` helper for blocks
- provide CLI utility `block_summary` to report block counts by size
- test grouping logic

## Testing
- `cargo test` *(fails: struct `PathGloss` is private)*

------
https://chatgpt.com/codex/tasks/task_e_687335f3912c8329a388746626f84d04