### PR TITLE
Fix PathGloss reexport

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use crate::compress::FallbackSeeds;
-use crate::path::PathGloss;
 
 pub const BLOCK_SIZE: usize = 3;
 


### PR DESCRIPTION
## Summary
- remove a private `use` that shadowed the public `PathGloss` re-export

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6873513f72b4832984d453d05af4f60d