### PR TITLE
Move bundling structs and helpers into new module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod block;
 mod bloom;
+mod bundle;
 mod compress;
 mod compress_stats;
 mod gloss;
@@ -11,25 +12,26 @@ mod seed_detect;
 mod seed_logger;
 mod sha_cache;
 mod stats;
-mod bundle;
 
 pub use block::{
     apply_block_changes, detect_bundles, group_by_bit_length, split_into_blocks, Block,
     BlockChange, BlockTable,
 };
 pub use bloom::*;
-pub use compress::{compress_block, dump_beliefmap_json, dump_gloss_to_csv, TruncHashTable};
+pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
+pub use compress::{
+    compress, compress_block, dump_beliefmap_json, dump_gloss_to_csv, TruncHashTable,
+};
 pub use compress_stats::{write_stats_csv, CompressionStats};
 pub use gloss::*;
 pub use gloss_prune_hook::run as gloss_prune_hook;
 pub use header::{decode_header, encode_header, Header, HeaderError};
 pub use live_window::{print_window, LiveStats};
 pub use path::*;
-pub use seed_detect::{detect_seed_matches, BlockStatus, MatchRecord, MutableBlock};
+pub use seed_detect::{detect_seed_matches, MatchRecord};
 pub use seed_logger::{log_seed, resume_seed_index, HashEntry};
 pub use sha_cache::*;
 pub use stats::Stats;
-pub use bundle::{BlockStatus, MutableBlock, apply_bundle};
 
 use crate::compress::FallbackSeeds;
 use crate::path::PathGloss as PathGlossPrivate;
@@ -51,4 +53,85 @@ pub fn print_compression_status(original: usize, compressed: usize) {
 pub enum Region {
     Raw(Vec<u8>),
     Compressed(Vec<u8>, Header),
+}
+
+/// Decompress a single region respecting a byte limit.
+pub fn decompress_region_with_limit(
+    region: &Region,
+    table: &GlossTable,
+    limit: usize,
+) -> Option<Vec<u8>> {
+    match region {
+        Region::Raw(bytes) => {
+            if bytes.len() <= limit {
+                Some(bytes.clone())
+            } else {
+                None
+            }
+        }
+        Region::Compressed(data, header) => {
+            if header.is_literal() {
+                let expected = if header.arity == 40 {
+                    data.len()
+                } else {
+                    (header.arity - 36) * BLOCK_SIZE
+                };
+                if data.len() != expected || data.len() > limit {
+                    return None;
+                }
+                Some(data.clone())
+            } else {
+                if header.seed_index >= table.entries.len() {
+                    return None;
+                }
+                let entry = &table.entries[header.seed_index];
+                if entry.decompressed.len() > limit {
+                    return None;
+                }
+                Some(entry.decompressed.clone())
+            }
+        }
+    }
+}
+
+/// Decompress a full byte stream with an optional limit.
+pub fn decompress_with_limit(input: &[u8], table: &GlossTable, limit: usize) -> Option<Vec<u8>> {
+    let mut offset = 0usize;
+    let mut out = Vec::new();
+    while offset < input.len() {
+        let (seed, arity, bits) = decode_header(&input[offset..]).ok()?;
+        offset += (bits + 7) / 8;
+        if arity >= 37 && arity <= 39 {
+            let blocks = arity - 36;
+            let bytes = blocks * BLOCK_SIZE;
+            if offset + bytes > input.len() || out.len() + bytes > limit {
+                return None;
+            }
+            out.extend_from_slice(&input[offset..offset + bytes]);
+            offset += bytes;
+        } else if arity == 40 {
+            let tail = &input[offset..];
+            if out.len() + tail.len() > limit {
+                return None;
+            }
+            out.extend_from_slice(tail);
+            offset = input.len();
+            break;
+        } else {
+            if seed >= table.entries.len() {
+                return None;
+            }
+            let entry = &table.entries[seed];
+            if out.len() + entry.decompressed.len() > limit {
+                return None;
+            }
+            out.extend_from_slice(&entry.decompressed);
+        }
+    }
+    Some(out)
+}
+
+/// Convenience wrapper without a limit.
+pub fn decompress(input: &[u8], table: &GlossTable) -> Vec<u8> {
+    decompress_with_limit(input, table, usize::MAX).unwrap_or_default()
 }

--- a/src/seed_detect.rs
+++ b/src/seed_detect.rs
@@ -1,25 +1,7 @@
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
-/// Status of a mutable block during compression.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlockStatus {
-    Active,
-    Inactive,
-}
-
-/// Mutable version of a block used during seed scanning.
-#[derive(Debug, Clone)]
-pub struct MutableBlock {
-    /// Position within the mutable table
-    pub position: usize,
-    /// Reference back to the original immutable block list
-    pub origin_index: usize,
-    /// Raw block bytes
-    pub data: Vec<u8>,
-    /// Whether this block is currently active
-    pub status: BlockStatus,
-}
+use crate::bundle::{BlockStatus, MutableBlock};
 
 /// A record of a block that matched a known seed prefix.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- centralize bundling helpers into `bundle.rs`
- export bundling API from crate root
- remove old definitions from `seed_detect`
- reintroduce simple compress/decompress helpers for tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687480d9e99c8329879bb3c645b8d63c