### PR TITLE
Add self-delimiting file header

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,4 +1,5 @@
 use crate::compress_stats::CompressionStats;
+use crate::file_header::encode_file_header;
 use crate::header::{encode_header, Header};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -62,8 +63,9 @@ impl TruncHashTable {
 /// Compress the input using literal passthrough encoding.
 /// Each chunk of up to 3 blocks is emitted with a header.
 /// Remaining bytes are stored as a literal tail with arity 40.
+
 pub fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
-    let mut out = Vec::new();
+    let mut out = encode_file_header(data, block_size);
     let mut offset = 0usize;
     while offset + block_size <= data.len() {
         let remaining_blocks = (data.len() - offset) / block_size;

--- a/src/file_header.rs
+++ b/src/file_header.rs
@@ -1,0 +1,60 @@
+use sha2::{Digest, Sha256};
+
+/// Encode a usize using LEB128 variable-length encoding.
+pub fn encode_varint(mut value: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+    out
+}
+
+/// Decode a usize from LEB128 encoding, updating the input offset.
+pub fn decode_varint(input: &[u8], offset: &mut usize) -> Option<usize> {
+    let mut result = 0usize;
+    let mut shift = 0usize;
+    while *offset < input.len() {
+        let byte = input[*offset];
+        *offset += 1;
+        result |= ((byte & 0x7f) as usize) << shift;
+        if byte & 0x80 == 0 {
+            return Some(result);
+        }
+        shift += 7;
+    }
+    None
+}
+
+/// Build a file header for the given data and block size.
+/// Returns the encoded header bytes.
+pub fn encode_file_header(data: &[u8], block_size: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&encode_varint(data.len()));
+    out.extend_from_slice(&encode_varint(block_size));
+    let digest: [u8; 32] = Sha256::digest(data).into();
+    out.extend_from_slice(&digest);
+    out
+}
+
+/// Parse a file header from the start of `input`.
+/// Returns the bytes consumed, original size, block size and sha256 hash.
+pub fn parse_file_header(input: &[u8]) -> Option<(usize, usize, usize, [u8; 32])> {
+    let mut offset = 0usize;
+    let orig_size = decode_varint(input, &mut offset)?;
+    let block_size = decode_varint(input, &mut offset)?;
+    if offset + 32 > input.len() {
+        return None;
+    }
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&input[offset..offset + 32]);
+    offset += 32;
+    Some((offset, orig_size, block_size, hash))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@ use inchworm::{compress, decompress, LiveStats};
 fn main() -> std::io::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 4 {
-        eprintln!("Usage: {} [c|d] <input> <output> [--block-size N] [--status] [--json] [--dry-run]", args[0]);
+        eprintln!(
+            "Usage: {} [c|d] <input> <output> [--block-size N] [--status] [--json] [--dry-run]",
+            args[0]
+        );
         return Ok(());
     }
 
@@ -32,9 +35,18 @@ fn main() -> std::io::Result<()> {
                 gloss_only = true;
                 i += 1;
             }
-            "--status" => { show_status = true; i += 1; }
-            "--json" => { json_out = true; i += 1; }
-            "--dry-run" => { dry_run = true; i += 1; }
+            "--status" => {
+                show_status = true;
+                i += 1;
+            }
+            "--json" => {
+                json_out = true;
+                i += 1;
+            }
+            "--dry-run" => {
+                dry_run = true;
+                i += 1;
+            }
             flag => {
                 eprintln!("Unknown flag: {}", flag);
                 return Ok(());
@@ -94,7 +106,7 @@ fn main() -> std::io::Result<()> {
         }
 
         "d" => {
-            let decompressed = decompress(&data, block_size);
+            let decompressed = decompress(&data);
             fs::write(&args[3], decompressed)?;
         }
 

--- a/tests/compress_literals.rs
+++ b/tests/compress_literals.rs
@@ -1,18 +1,21 @@
-use inchworm::{compress, decompress_with_limit, decode_header, Header};
+use inchworm::{compress, decode_header, decompress_with_limit, parse_file_header, Header};
 
 #[test]
 fn compress_emits_literal_headers() {
     let block_size = 3; // Or whatever you want to test!
     let data: Vec<u8> = (0u8..50).collect();
     let out = compress(&data, block_size);
-    let decompressed = decompress_with_limit(&out, block_size, usize::MAX).unwrap();
+    let decompressed = decompress_with_limit(&out, usize::MAX).unwrap();
     assert_eq!(decompressed, data);
 
-    let mut offset = 0usize;
+    let (mut offset, _, _, _) = parse_file_header(&out).unwrap();
     let mut idx = 0usize;
     while offset < out.len() {
         let (seed, arity, bits) = decode_header(&out[offset..]).unwrap();
-        let header = Header { seed_index: seed, arity };
+        let header = Header {
+            seed_index: seed,
+            arity,
+        };
         offset += (bits + 7) / 8;
         assert_eq!(header.seed_index, 0);
         if header.arity == 40 {
@@ -24,7 +27,10 @@ fn compress_emits_literal_headers() {
             assert!(header.arity >= 37 && header.arity <= 39);
             let blocks = header.arity - 36;
             let byte_count = blocks * block_size;
-            assert_eq!(&out[offset..offset + byte_count], &data[idx..idx + byte_count]);
+            assert_eq!(
+                &out[offset..offset + byte_count],
+                &data[idx..idx + byte_count]
+            );
             offset += byte_count;
             idx += byte_count;
         }

--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -1,16 +1,14 @@
-use inchworm::{
-    decompress_with_limit,
-    encode_header,
-};
+use inchworm::{decompress_with_limit, encode_file_header, encode_header};
 
 #[test]
 fn passthrough_decompresses() {
     let block_size = 3;
     let header = encode_header(0, 37); // passthrough 1 block
     let literal = vec![0x11; 1 * block_size];
-    let mut data = header.clone();
+    let mut data = encode_file_header(&literal, block_size);
+    data.extend_from_slice(&header);
     data.extend_from_slice(&literal);
-    let out = decompress_with_limit(&data, block_size, literal.len()).unwrap();
+    let out = decompress_with_limit(&data, literal.len()).unwrap();
     assert_eq!(out, literal);
 }
 
@@ -19,9 +17,10 @@ fn passthrough_respects_limit() {
     let block_size = 3;
     let header = encode_header(0, 38); // passthrough 2 blocks
     let literal = vec![0x22; 2 * block_size];
-    let mut data = header.clone();
+    let mut data = encode_file_header(&literal, block_size);
+    data.extend_from_slice(&header);
     data.extend_from_slice(&literal);
-    assert!(decompress_with_limit(&data, block_size, literal.len() - 1).is_none());
+    assert!(decompress_with_limit(&data, literal.len() - 1).is_none());
 }
 
 #[test]
@@ -29,18 +28,20 @@ fn passthrough_prefix_safe() {
     let block_size = 3;
     let header = encode_header(0, 39); // passthrough 3 blocks
     let literal = vec![0x33; 3 * block_size - 1]; // intentionally 1 byte short
-    let mut data = header.clone();
+    let mut data = encode_file_header(&literal, block_size);
+    data.extend_from_slice(&header);
     data.extend_from_slice(&literal);
-    assert!(decompress_with_limit(&data, block_size, usize::MAX).is_none());
+    assert!(decompress_with_limit(&data, usize::MAX).is_none());
 }
 
 #[test]
 fn passthrough_literals_basic() {
     let block_size = 3;
     let literals: Vec<u8> = (0u8..(block_size as u8 * 2)).collect();
-    let mut data = encode_header(0, 38); // passthrough 2 blocks
+    let mut data = encode_file_header(&literals, block_size);
+    data.extend_from_slice(&encode_header(0, 38)); // passthrough 2 blocks
     data.extend_from_slice(&literals);
-    let out = decompress_with_limit(&data, block_size, 100).unwrap();
+    let out = decompress_with_limit(&data, 100).unwrap();
     assert_eq!(out, literals);
 }
 
@@ -48,8 +49,9 @@ fn passthrough_literals_basic() {
 fn passthrough_final_tail() {
     let block_size = 3;
     let literals: Vec<u8> = (0u8..5).collect();
-    let mut data = encode_header(0, 40); // final tail
+    let mut data = encode_file_header(&literals, block_size);
+    data.extend_from_slice(&encode_header(0, 40)); // final tail
     data.extend_from_slice(&literals);
-    let out = decompress_with_limit(&data, block_size, 100).unwrap();
+    let out = decompress_with_limit(&data, 100).unwrap();
     assert_eq!(out, literals);
 }

--- a/tests/gloss_passthrough.rs
+++ b/tests/gloss_passthrough.rs
@@ -5,6 +5,6 @@ fn mixed_gloss_and_passthrough() {
     let block_size = 3;
     let input = b"hello!!!abcxyz!".to_vec(); // "hello!!!" is glossed, rest is passthrough
     let compressed = compress(&input, block_size);
-    let output = decompress(&compressed, block_size);
+    let output = decompress(&compressed);
     assert_eq!(input, output);
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -6,6 +6,6 @@ fn compression_roundtrip_identity() {
     let input: Vec<u8> = (0..100u8).collect();
 
     let output = compress(&input, block_size);
-    let reconstructed = decompress(&output, block_size);
+    let reconstructed = decompress(&output);
     assert_eq!(input, reconstructed);
 }


### PR DESCRIPTION
## Summary
- introduce `file_header` module for compact stream headers
- emit file header from `compress()`
- parse and use file header in `decompress()`
- update CLI and tests for the new header

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6875162afac08329bbdff24a47d5122c