### PR TITLE
Add support for reserved literal codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ literals using a reserved fallback byte.
 
 Run `cargo run -- c <input> <output>` to compress a file or `cargo run -- d
 <input> <output>` to decompress.
+
+## Arity Codes
+
+The decompressor recognizes special 8‑bit codes for literal and terminal data:
+
+* **29** – one literal block
+* **30** – two literal blocks
+* **31** – three literal blocks
+* **32** – terminal tail of less than one block
+
+These codes bypass the variable length header parser and are followed
+immediately by the indicated bytes. Blocks outside this range continue
+using the normal header scheme.

--- a/src/header.rs
+++ b/src/header.rs
@@ -10,7 +10,7 @@ pub struct Header {
 impl Header {
     /// Returns true if this header represents a literal passthrough region.
     pub fn is_literal(&self) -> bool {
-        matches!(self.arity, 37 | 38 | 39 | 40)
+        matches!(self.arity, 29 | 30 | 31 | 32 | 37 | 38 | 39 | 40)
     }
 }
 

--- a/tests/reserved_literals.rs
+++ b/tests/reserved_literals.rs
@@ -1,0 +1,33 @@
+use inchworm::{decompress_with_limit, encode_file_header};
+
+fn encode_reserved(data: &[u8], block_size: usize) -> Vec<u8> {
+    let mut out = encode_file_header(data, block_size);
+    let mut offset = 0usize;
+    while offset + block_size <= data.len() {
+        let remaining_blocks = (data.len() - offset) / block_size;
+        let blocks = remaining_blocks.min(3).max(1);
+        let code = match blocks {
+            1 => 29u8,
+            2 => 30u8,
+            _ => 31u8,
+        };
+        out.push(code);
+        let bytes = blocks * block_size;
+        out.extend_from_slice(&data[offset..offset + bytes]);
+        offset += bytes;
+    }
+    out.push(32u8);
+    out.extend_from_slice(&data[offset..]);
+    out
+}
+
+#[test]
+fn reserved_roundtrip_various_lengths() {
+    let block_size = 4;
+    for len in 1usize..20 {
+        let data: Vec<u8> = (0..len as u8).collect();
+        let encoded = encode_reserved(&data, block_size);
+        let out = decompress_with_limit(&encoded, usize::MAX).unwrap();
+        assert_eq!(out, data);
+    }
+}


### PR DESCRIPTION
## Summary
- parse new single-byte codes 29-32 in the decompressor
- document reserved code handling
- support literal/tail blocks in `decompress_region_with_limit`
- add regression tests covering these codes

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68751d99979c8329a3d0598c53293de6