### PR TITLE
Add EVQL file header handling

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -65,7 +65,7 @@ impl TruncHashTable {
 /// Remaining bytes are stored as a literal tail with arity 40.
 
 pub fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
-    let mut out = encode_file_header(data, block_size);
+    let mut out = encode_file_header(data.len(), block_size);
     let mut offset = 0usize;
     while offset + block_size <= data.len() {
         let remaining_blocks = (data.len() - offset) / block_size;

--- a/src/file_header.rs
+++ b/src/file_header.rs
@@ -1,60 +1,102 @@
-use sha2::{Digest, Sha256};
+use std::cmp;
 
-/// Encode a usize using LEB128 variable-length encoding.
-pub fn encode_varint(mut value: usize) -> Vec<u8> {
-    let mut out = Vec::new();
+/// Encode a usize using EVQL (Exponentially Variable Quantity Length).
+/// The value width is a power of two in bytes. The prefix is encoded as
+/// `n` one bits followed by a zero bit where `2^n` is the number of bytes
+/// used to store the value. The bits are packed big endian.
+pub fn encode_evql(mut value: usize) -> Vec<u8> {
+    let mut width = 1usize;
+    let mut n = 0usize;
+    while value >= (1usize << (width * 8)) {
+        width <<= 1;
+        n += 1;
+    }
+    let mut bits = Vec::new();
+    for _ in 0..n {
+        bits.push(true);
+    }
+    bits.push(false);
+    for i in (0..(width * 8)).rev() {
+        bits.push(((value >> i) & 1) != 0);
+    }
+    pack_bits(&bits)
+}
+
+/// Decode a usize from EVQL encoding. Returns `(value, bytes_consumed)`.
+pub fn decode_evql(data: &[u8]) -> Option<(usize, usize)> {
+    let mut pos = 0usize;
+    let mut n = 0usize;
     loop {
-        let mut byte = (value & 0x7f) as u8;
-        value >>= 7;
-        if value != 0 {
-            byte |= 0x80;
-        }
-        out.push(byte);
-        if value == 0 {
-            break;
+        match get_bit(data, pos) {
+            Some(true) => {
+                n += 1;
+                pos += 1;
+            }
+            Some(false) => {
+                pos += 1;
+                break;
+            }
+            None => return None,
         }
     }
-    out
-}
-
-/// Decode a usize from LEB128 encoding, updating the input offset.
-pub fn decode_varint(input: &[u8], offset: &mut usize) -> Option<usize> {
-    let mut result = 0usize;
-    let mut shift = 0usize;
-    while *offset < input.len() {
-        let byte = input[*offset];
-        *offset += 1;
-        result |= ((byte & 0x7f) as usize) << shift;
-        if byte & 0x80 == 0 {
-            return Some(result);
+    let width = 1usize << n;
+    let mut value = 0usize;
+    for _ in 0..(width * 8) {
+        match get_bit(data, pos) {
+            Some(bit) => {
+                value = (value << 1) | (bit as usize);
+                pos += 1;
+            }
+            None => return None,
         }
-        shift += 7;
     }
-    None
+    Some((value, (pos + 7) / 8))
 }
 
-/// Build a file header for the given data and block size.
+/// Build a file header using EVQL encoded file and block sizes.
 /// Returns the encoded header bytes.
-pub fn encode_file_header(data: &[u8], block_size: usize) -> Vec<u8> {
+pub fn encode_file_header(file_size: usize, block_size: usize) -> Vec<u8> {
     let mut out = Vec::new();
-    out.extend_from_slice(&encode_varint(data.len()));
-    out.extend_from_slice(&encode_varint(block_size));
-    let digest: [u8; 32] = Sha256::digest(data).into();
-    out.extend_from_slice(&digest);
+    out.extend_from_slice(&encode_evql(file_size));
+    out.extend_from_slice(&encode_evql(block_size));
     out
 }
 
-/// Parse a file header from the start of `input`.
-/// Returns the bytes consumed, original size, block size and sha256 hash.
-pub fn parse_file_header(input: &[u8]) -> Option<(usize, usize, usize, [u8; 32])> {
-    let mut offset = 0usize;
-    let orig_size = decode_varint(input, &mut offset)?;
-    let block_size = decode_varint(input, &mut offset)?;
-    if offset + 32 > input.len() {
-        return None;
+/// Parse an EVQL header from the start of `data`.
+/// Returns `(bytes_consumed, file_size, block_size)`.
+pub fn decode_file_header(data: &[u8]) -> Option<(usize, usize, usize)> {
+    let (file_size, used1) = decode_evql(data)?;
+    let (block_size, used2) = decode_evql(&data[used1..])?;
+    Some((used1 + used2, file_size, block_size))
+}
+
+fn get_bit(input: &[u8], pos: usize) -> Option<bool> {
+    if pos / 8 >= input.len() {
+        None
+    } else {
+        Some(((input[pos / 8] >> (7 - (pos % 8))) & 1) != 0)
     }
-    let mut hash = [0u8; 32];
-    hash.copy_from_slice(&input[offset..offset + 32]);
-    offset += 32;
-    Some((offset, orig_size, block_size, hash))
+}
+
+fn pack_bits(bits: &[bool]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut byte = 0u8;
+    let mut used = 0u8;
+    for &b in bits {
+        byte = (byte << 1) | (b as u8);
+        used += 1;
+        if used == 8 {
+            out.push(byte);
+            byte = 0;
+            used = 0;
+        }
+    }
+    if used > 0 {
+        byte <<= 8 - used;
+        out.push(byte);
+    }
+    if out.is_empty() {
+        out.push(0);
+    }
+    out
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use block::{
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
 pub use compress::{compress, compress_block, TruncHashTable};
 pub use compress_stats::{write_stats_csv, CompressionStats};
-pub use file_header::{encode_file_header, parse_file_header};
+pub use file_header::{decode_file_header, encode_file_header};
 pub use header::{decode_header, encode_header, Header, HeaderError};
 pub use live_window::{print_window, LiveStats};
 pub use path::*;
@@ -90,7 +90,7 @@ pub fn decompress_with_limit(input: &[u8], limit: usize) -> Option<Vec<u8>> {
     if input.is_empty() {
         return Some(Vec::new());
     }
-    let (mut offset, orig_size, block_size, _hash) = parse_file_header(input)?;
+    let (mut offset, orig_size, block_size) = decode_file_header(input)?;
     let mut out = Vec::new();
     while offset < input.len() {
         // Fast path for reserved single-byte literals and terminal blocks.

--- a/tests/compress_literals.rs
+++ b/tests/compress_literals.rs
@@ -1,4 +1,4 @@
-use inchworm::{compress, decode_header, decompress_with_limit, parse_file_header, Header};
+use inchworm::{compress, decode_file_header, decode_header, decompress_with_limit, Header};
 
 #[test]
 fn compress_emits_literal_headers() {
@@ -8,7 +8,7 @@ fn compress_emits_literal_headers() {
     let decompressed = decompress_with_limit(&out, usize::MAX).unwrap();
     assert_eq!(decompressed, data);
 
-    let (mut offset, _, _, _) = parse_file_header(&out).unwrap();
+    let (mut offset, _, _) = decode_file_header(&out).unwrap();
     let mut idx = 0usize;
     while offset < out.len() {
         let (seed, arity, bits) = decode_header(&out[offset..]).unwrap();

--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -5,7 +5,7 @@ fn passthrough_decompresses() {
     let block_size = 3;
     let header = encode_header(0, 37); // passthrough 1 block
     let literal = vec![0x11; 1 * block_size];
-    let mut data = encode_file_header(&literal, block_size);
+    let mut data = encode_file_header(literal.len(), block_size);
     data.extend_from_slice(&header);
     data.extend_from_slice(&literal);
     let out = decompress_with_limit(&data, literal.len()).unwrap();
@@ -17,7 +17,7 @@ fn passthrough_respects_limit() {
     let block_size = 3;
     let header = encode_header(0, 38); // passthrough 2 blocks
     let literal = vec![0x22; 2 * block_size];
-    let mut data = encode_file_header(&literal, block_size);
+    let mut data = encode_file_header(literal.len(), block_size);
     data.extend_from_slice(&header);
     data.extend_from_slice(&literal);
     assert!(decompress_with_limit(&data, literal.len() - 1).is_none());
@@ -28,7 +28,7 @@ fn passthrough_prefix_safe() {
     let block_size = 3;
     let header = encode_header(0, 39); // passthrough 3 blocks
     let literal = vec![0x33; 3 * block_size - 1]; // intentionally 1 byte short
-    let mut data = encode_file_header(&literal, block_size);
+    let mut data = encode_file_header(literal.len(), block_size);
     data.extend_from_slice(&header);
     data.extend_from_slice(&literal);
     assert!(decompress_with_limit(&data, usize::MAX).is_none());
@@ -38,7 +38,7 @@ fn passthrough_prefix_safe() {
 fn passthrough_literals_basic() {
     let block_size = 3;
     let literals: Vec<u8> = (0u8..(block_size as u8 * 2)).collect();
-    let mut data = encode_file_header(&literals, block_size);
+    let mut data = encode_file_header(literals.len(), block_size);
     data.extend_from_slice(&encode_header(0, 38)); // passthrough 2 blocks
     data.extend_from_slice(&literals);
     let out = decompress_with_limit(&data, 100).unwrap();
@@ -49,7 +49,7 @@ fn passthrough_literals_basic() {
 fn passthrough_final_tail() {
     let block_size = 3;
     let literals: Vec<u8> = (0u8..5).collect();
-    let mut data = encode_file_header(&literals, block_size);
+    let mut data = encode_file_header(literals.len(), block_size);
     data.extend_from_slice(&encode_header(0, 40)); // final tail
     data.extend_from_slice(&literals);
     let out = decompress_with_limit(&data, 100).unwrap();

--- a/tests/reserved_literals.rs
+++ b/tests/reserved_literals.rs
@@ -1,7 +1,7 @@
 use inchworm::{decompress_with_limit, encode_file_header};
 
 fn encode_reserved(data: &[u8], block_size: usize) -> Vec<u8> {
-    let mut out = encode_file_header(data, block_size);
+    let mut out = encode_file_header(data.len(), block_size);
     let mut offset = 0usize;
     while offset + block_size <= data.len() {
         let remaining_blocks = (data.len() - offset) / block_size;


### PR DESCRIPTION
## Summary
- implement EVQL encoding/decoding and use it for file headers
- remove legacy LEB128 header code and SHA-256 digest
- update compressor and decompressor to read/write EVQL headers
- adjust CLI tests and helpers for new file header API

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687520e7fbf083299b9d30c7330eb297