### PR TITLE
Refactor dynamic block table management

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ mod sha_cache;
 mod stats;
 
 pub use block::{
-    apply_block_changes, detect_bundles, group_by_bit_length, split_into_blocks, Block,
-    BlockChange, BlockTable,
+    apply_block_changes, detect_bundles, group_by_bit_length, run_all_passes, split_into_blocks,
+    Block, BlockChange, BlockTable,
 };
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
 pub use compress::{compress, compress_block, TruncHashTable};

--- a/tests/block_changes.rs
+++ b/tests/block_changes.rs
@@ -1,16 +1,37 @@
-use inchworm::{Block, BlockChange, group_by_bit_length, apply_block_changes};
+use inchworm::{apply_block_changes, group_by_bit_length, Block, BlockChange};
 
 #[test]
 fn apply_single_change() {
     let blocks = vec![
-        Block { global_index: 0, bit_length: 8, data: vec![1], arity: None, seed_index: None },
-        Block { global_index: 1, bit_length: 8, data: vec![2], arity: None, seed_index: None },
+        Block {
+            global_index: 0,
+            bit_length: 8,
+            data: vec![1],
+            arity: None,
+            seed_index: None,
+        },
+        Block {
+            global_index: 1,
+            bit_length: 8,
+            data: vec![2],
+            arity: None,
+            seed_index: None,
+        },
     ];
     let mut table = group_by_bit_length(blocks);
     assert_eq!(table.get(&8).unwrap().len(), 2);
 
-    let new = Block { global_index: 0, bit_length: 16, data: vec![3,4], arity: None, seed_index: Some(0) };
-    let change = BlockChange { original_index: 1, new_block: new };
+    let new = Block {
+        global_index: 0,
+        bit_length: 16,
+        data: vec![3, 4],
+        arity: None,
+        seed_index: Some(0),
+    };
+    let change = BlockChange {
+        original_index: 1,
+        new_block: new,
+    };
 
     apply_block_changes(&mut table, vec![change]);
 

--- a/tests/table_bounds.rs
+++ b/tests/table_bounds.rs
@@ -1,0 +1,17 @@
+use inchworm::{group_by_bit_length, run_all_passes, split_into_blocks};
+use std::collections::HashMap;
+
+#[test]
+fn table_counts_within_bounds() {
+    let seed_table: HashMap<String, usize> = HashMap::new();
+    let max_tables = 256usize;
+    for size in [1usize, 8, 16, 32, 64, 128] {
+        let data: Vec<u8> = (0..size as u8).collect();
+        for bits in (8..=64).step_by(8) {
+            let blocks = split_into_blocks(&data, bits);
+            let table = group_by_bit_length(blocks);
+            let out = run_all_passes(table, &seed_table);
+            assert!(out.group_count() <= max_tables);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `BlockTable` struct to manage block groups without removal
- keep even-length tables alive and clear when empty
- expose `run_all_passes` and clean empty tables after each pass
- update tests and add a harness confirming table counts stay within bounds

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68752770dad483299f6957a306556fc5