### PR TITLE
Add superposition pruning and collapse logic

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -185,6 +185,108 @@ pub fn print_table_summary(table: &BlockTable) {
     }
 }
 
+/// Prune superposed branches whose bit-length delta exceeds eight bits.
+pub fn prune_branches(table: &mut BlockTable) {
+    use std::collections::HashMap;
+
+    let mut by_index: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
+    for (len, group) in table.iter() {
+        for (idx, block) in group.iter().enumerate() {
+            by_index
+                .entry(block.global_index)
+                .or_default()
+                .push((*len, idx));
+        }
+    }
+
+    let mut remove_map: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (_idx, branches) in by_index {
+        if branches.len() <= 1 {
+            continue;
+        }
+        let min_len = branches.iter().map(|b| b.0).min().unwrap();
+        let max_len = branches.iter().map(|b| b.0).max().unwrap();
+        if max_len - min_len > 8 {
+            for (len, pos) in branches.iter().filter(|b| b.0 == max_len) {
+                remove_map.entry(*len).or_default().push(*pos);
+            }
+        }
+    }
+
+    for (len, mut positions) in remove_map {
+        if let Some(group) = table.groups.get_mut(&len) {
+            positions.sort_unstable_by(|a, b| b.cmp(a));
+            positions.dedup();
+            for pos in positions {
+                if pos < group.len() {
+                    group.remove(pos);
+                }
+            }
+        }
+    }
+}
+
+/// Collapse all branches from the given index onward, keeping the shortest.
+pub fn collapse_branches(table: &mut BlockTable, start_index: usize) {
+    use std::collections::HashMap;
+
+    let mut by_index: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
+    for (len, group) in table.iter() {
+        for (idx, block) in group.iter().enumerate() {
+            if block.global_index >= start_index {
+                by_index
+                    .entry(block.global_index)
+                    .or_default()
+                    .push((*len, idx));
+            }
+        }
+    }
+
+    let mut remove_map: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (_idx, branches) in by_index {
+        if branches.len() <= 1 {
+            continue;
+        }
+        let min_len = branches.iter().map(|b| b.0).min().unwrap();
+        for (len, pos) in branches.into_iter().filter(|b| b.0 != min_len) {
+            remove_map.entry(len).or_default().push(pos);
+        }
+    }
+
+    for (len, mut positions) in remove_map {
+        if let Some(group) = table.groups.get_mut(&len) {
+            positions.sort_unstable_by(|a, b| b.cmp(a));
+            positions.dedup();
+            for pos in positions {
+                if pos < group.len() {
+                    group.remove(pos);
+                }
+            }
+        }
+    }
+}
+
+/// Finalize the table into a single block per global index.
+pub fn finalize_table(mut table: BlockTable) -> Vec<Block> {
+    use std::collections::HashMap;
+
+    let mut map: HashMap<usize, Block> = HashMap::new();
+    for (_, group) in table.groups.drain() {
+        for block in group.into_iter() {
+            map.entry(block.global_index)
+                .and_modify(|b| {
+                    if block.bit_length < b.bit_length {
+                        *b = block.clone();
+                    }
+                })
+                .or_insert(block);
+        }
+    }
+    let mut out: Vec<Block> = map.into_iter().map(|(_, b)| b).collect();
+    out.sort_by_key(|b| b.global_index);
+    out
+}
+
 /// Detect potential bundled blocks after a pass (stub).
 pub fn detect_bundles(_table: &mut BlockTable) {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ mod sha_cache;
 mod stats;
 
 pub use block::{
-    apply_block_changes, detect_bundles, group_by_bit_length, run_all_passes, split_into_blocks,
-    Block, BlockChange, BlockTable,
+    apply_block_changes, collapse_branches, detect_bundles, finalize_table, group_by_bit_length,
+    prune_branches, run_all_passes, split_into_blocks, Block, BlockChange, BlockTable,
 };
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
 pub use compress::{compress, compress_block, TruncHashTable};

--- a/tests/branch_pruning.rs
+++ b/tests/branch_pruning.rs
@@ -1,0 +1,45 @@
+use inchworm::{group_by_bit_length, Block, prune_branches, collapse_branches, finalize_table};
+
+#[test]
+fn prune_removes_longest() {
+    let blocks = vec![
+        Block { global_index: 0, bit_length: 8, data: vec![0], arity: None, seed_index: None },
+        Block { global_index: 0, bit_length: 24, data: vec![1,2,3], arity: None, seed_index: None },
+        Block { global_index: 1, bit_length: 8, data: vec![4], arity: None, seed_index: None },
+    ];
+    let mut table = group_by_bit_length(blocks);
+    prune_branches(&mut table);
+    // index 0 should only have 8-bit block
+    assert_eq!(table.get(&8).unwrap().iter().filter(|b| b.global_index == 0).count(), 1);
+    assert!(table.get(&24).map_or(true, |v| v.iter().all(|b| b.global_index != 0)));
+}
+
+#[test]
+fn collapse_from_index() {
+    let blocks = vec![
+        Block { global_index: 0, bit_length: 8, data: vec![0], arity: None, seed_index: None },
+        Block { global_index: 0, bit_length: 16, data: vec![1,2], arity: None, seed_index: None },
+        Block { global_index: 1, bit_length: 8, data: vec![3], arity: None, seed_index: None },
+        Block { global_index: 1, bit_length: 16, data: vec![4,5], arity: None, seed_index: None },
+    ];
+    let mut table = group_by_bit_length(blocks);
+    collapse_branches(&mut table, 0);
+    assert_eq!(table.get(&8).unwrap().iter().filter(|b| b.global_index == 0).count(), 1);
+    assert!(table.get(&16).map_or(true, |v| v.iter().all(|b| b.global_index != 0)));
+    assert_eq!(table.get(&8).unwrap().iter().filter(|b| b.global_index == 1).count(), 1);
+}
+
+#[test]
+fn finalize_unique_blocks() {
+    let blocks = vec![
+        Block { global_index: 0, bit_length: 16, data: vec![0,1], arity: None, seed_index: None },
+        Block { global_index: 0, bit_length: 8, data: vec![2], arity: None, seed_index: None },
+        Block { global_index: 1, bit_length: 8, data: vec![3], arity: None, seed_index: None },
+    ];
+    let table = group_by_bit_length(blocks);
+    let final_blocks = finalize_table(table);
+    assert_eq!(final_blocks.len(), 2);
+    assert_eq!(final_blocks[0].global_index, 0);
+    assert_eq!(final_blocks[0].bit_length, 8);
+    assert_eq!(final_blocks[1].global_index, 1);
+}


### PR DESCRIPTION
## Summary
- implement `prune_branches` to drop far longer candidates
- implement `collapse_branches` and `finalize_table`
- export new helpers
- test pruning, collapse and finalization

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6875b9955c2483299ad936d99fc599c8