### PR TITLE
Implement 3‑byte Telomere header

### DIFF
--- a/src/tlmr.rs
+++ b/src/tlmr.rs
@@ -1,0 +1,77 @@
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Representation of the Telomere 3-byte file header.
+///
+/// Bits are packed big endian starting with the most significant bit.
+/// Field layout (bit indices 0..23):
+/// - bits 0..=2   : protocol version
+/// - bits 3..=6   : block size code (stored value + 1 = actual block size)
+/// - bits 7..=10  : last block size code (stored value + 1 = bytes in final block)
+/// - bits 11..=23 : lowest 13 bits of the SHA-256 of the decompressed output
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlmrHeader {
+    pub version: u8,
+    pub block_size: usize,
+    pub last_block_size: usize,
+    pub output_hash: u16,
+}
+
+/// Errors that can occur while decoding or validating the header.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TlmrError {
+    #[error("header too short")]
+    TooShort,
+    #[error("invalid header field")]
+    InvalidField,
+    #[error("output hash mismatch")]
+    OutputHashMismatch,
+}
+
+/// Encode the Telomere header with protocol version 0.
+pub fn encode_tlmr_header(header: &TlmrHeader) -> [u8; 3] {
+    assert!(header.version <= 7, "version out of range");
+    assert!(header.block_size >= 1 && header.block_size <= 16, "block size out of range");
+    assert!(header.last_block_size >= 1 && header.last_block_size <= 16, "last block size out of range");
+    let mut val: u32 = 0;
+    val |= (header.version as u32 & 0x7) << 21;
+    val |= ((header.block_size as u32 - 1) & 0xF) << 17;
+    val |= ((header.last_block_size as u32 - 1) & 0xF) << 13;
+    val |= (header.output_hash as u32) & 0x1FFF;
+    [
+        ((val >> 16) & 0xFF) as u8,
+        ((val >> 8) & 0xFF) as u8,
+        (val & 0xFF) as u8,
+    ]
+}
+
+/// Decode a Telomere header from the first three bytes of the input.
+pub fn decode_tlmr_header(data: &[u8]) -> Result<TlmrHeader, TlmrError> {
+    if data.len() < 3 {
+        return Err(TlmrError::TooShort);
+    }
+    let val = ((data[0] as u32) << 16) | ((data[1] as u32) << 8) | data[2] as u32;
+    let version = ((val >> 21) & 0x7) as u8;
+    let bs_code = ((val >> 17) & 0xF) as u8;
+    let lbs_code = ((val >> 13) & 0xF) as u8;
+    let hash = (val & 0x1FFF) as u16;
+    let block_size = bs_code as usize + 1;
+    let last_block_size = lbs_code as usize + 1;
+    if version > 7 || block_size == 0 || block_size > 16 || last_block_size == 0 || last_block_size > 16 {
+        return Err(TlmrError::InvalidField);
+    }
+    Ok(TlmrHeader {
+        version,
+        block_size,
+        last_block_size,
+        output_hash: hash,
+    })
+}
+
+/// Compute the 13-bit truncated SHA-256 of the provided bytes.
+pub fn truncated_hash(data: &[u8]) -> u16 {
+    let digest = Sha256::digest(data);
+    let arr: [u8; 32] = digest.into();
+    let low = ((arr[30] as u16) << 8) | arr[31] as u16;
+    low & 0x1FFF
+}

--- a/tests/branch_pruning.rs
+++ b/tests/branch_pruning.rs
@@ -3,9 +3,9 @@ use inchworm::{group_by_bit_length, Block, prune_branches, collapse_branches, fi
 #[test]
 fn prune_removes_longest() {
     let blocks = vec![
-        Block { global_index: 0, bit_length: 8, data: vec![0], arity: None, seed_index: None },
-        Block { global_index: 0, bit_length: 24, data: vec![1,2,3], arity: None, seed_index: None },
-        Block { global_index: 1, bit_length: 8, data: vec![4], arity: None, seed_index: None },
+        Block { global_index: 0, bit_length: 8, data: vec![0], digest: [0u8;32], arity: None, seed_index: None, branch_label: 'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 0, bit_length: 24, data: vec![1,2,3], digest: [0u8;32], arity: None, seed_index: None, branch_label: 'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 1, bit_length: 8, data: vec![4], digest: [0u8;32], arity: None, seed_index: None, branch_label: 'A', status: inchworm::BranchStatus::Active },
     ];
     let mut table = group_by_bit_length(blocks);
     prune_branches(&mut table);
@@ -17,10 +17,10 @@ fn prune_removes_longest() {
 #[test]
 fn collapse_from_index() {
     let blocks = vec![
-        Block { global_index: 0, bit_length: 8, data: vec![0], arity: None, seed_index: None },
-        Block { global_index: 0, bit_length: 16, data: vec![1,2], arity: None, seed_index: None },
-        Block { global_index: 1, bit_length: 8, data: vec![3], arity: None, seed_index: None },
-        Block { global_index: 1, bit_length: 16, data: vec![4,5], arity: None, seed_index: None },
+        Block { global_index: 0, bit_length: 8, data: vec![0], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 0, bit_length: 16, data: vec![1,2], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 1, bit_length: 8, data: vec![3], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 1, bit_length: 16, data: vec![4,5], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
     ];
     let mut table = group_by_bit_length(blocks);
     collapse_branches(&mut table, 0);
@@ -32,9 +32,9 @@ fn collapse_from_index() {
 #[test]
 fn finalize_unique_blocks() {
     let blocks = vec![
-        Block { global_index: 0, bit_length: 16, data: vec![0,1], arity: None, seed_index: None },
-        Block { global_index: 0, bit_length: 8, data: vec![2], arity: None, seed_index: None },
-        Block { global_index: 1, bit_length: 8, data: vec![3], arity: None, seed_index: None },
+        Block { global_index: 0, bit_length: 16, data: vec![0,1], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 0, bit_length: 8, data: vec![2], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
+        Block { global_index: 1, bit_length: 8, data: vec![3], digest:[0u8;32], arity: None, seed_index: None, branch_label:'A', status: inchworm::BranchStatus::Active },
     ];
     let table = group_by_bit_length(blocks);
     let final_blocks = finalize_table(table);

--- a/tests/compress_literals.rs
+++ b/tests/compress_literals.rs
@@ -1,4 +1,4 @@
-use inchworm::{compress, decode_file_header, decode_header, decompress_with_limit, Header};
+use inchworm::{compress, decode_header, decode_tlmr_header, decompress_with_limit, Header};
 
 #[test]
 fn compress_writes_header_then_data() {
@@ -8,9 +8,10 @@ fn compress_writes_header_then_data() {
     let decompressed = decompress_with_limit(&out, usize::MAX).unwrap();
     assert_eq!(decompressed, data);
 
-    let (mut offset, len, bs) = decode_file_header(&out).unwrap();
-    assert_eq!(len, data.len());
-    assert_eq!(bs, block_size);
+    let header = decode_tlmr_header(&out).unwrap();
+    assert_eq!(header.block_size, block_size);
+    assert_eq!(header.last_block_size, if data.len() % block_size == 0 { block_size } else { data.len() % block_size });
+    let mut offset = 3usize;
     let mut idx = 0usize;
 
     while offset < out.len() {

--- a/tests/tlmr_header.rs
+++ b/tests/tlmr_header.rs
@@ -1,0 +1,70 @@
+use inchworm::{
+    decode_tlmr_header, encode_header, encode_tlmr_header, decompress_with_limit,
+    truncated_hash, TlmrHeader, compress,
+};
+
+#[test]
+fn header_bit_roundtrip() {
+    for version in 0u8..=7 {
+        for bs in 1usize..=16 {
+            for last in 1usize..=16 {
+                let h = TlmrHeader {
+                    version,
+                    block_size: bs,
+                    last_block_size: last,
+                    output_hash: 0x1FFF,
+                };
+                let enc = encode_tlmr_header(&h);
+                let decoded = decode_tlmr_header(&enc).unwrap();
+                assert_eq!(decoded, h);
+            }
+        }
+    }
+}
+
+fn build_data(bytes: &[u8], bs: usize) -> Vec<u8> {
+    let last = if bytes.is_empty() { bs } else { (bytes.len() - 1) % bs + 1 };
+    let hdr = encode_tlmr_header(&TlmrHeader { version: 0, block_size: bs, last_block_size: last, output_hash: truncated_hash(bytes) });
+    let mut out = hdr.to_vec();
+    let mut offset = 0usize;
+    while offset + bs <= bytes.len() {
+        let blocks = 1usize;
+        out.extend_from_slice(&encode_header(0, 28 + blocks));
+        out.extend_from_slice(&bytes[offset..offset + bs]);
+        offset += bs;
+    }
+    if offset < bytes.len() {
+        out.extend_from_slice(&encode_header(0, 32));
+        out.extend_from_slice(&bytes[offset..]);
+    }
+    out
+}
+
+#[test]
+fn wrong_last_block_size_fails() {
+    let bs = 4;
+    let data: Vec<u8> = (0u8..10).collect();
+    let mut buf = build_data(&data, bs);
+    // corrupt last block size in header
+    buf[0] ^= 0b0001_0000; // tweak block size bits to change last block size
+    assert!(decompress_with_limit(&buf, usize::MAX).is_err());
+}
+
+#[test]
+fn wrong_hash_fails() {
+    let bs = 4;
+    let data: Vec<u8> = (0u8..10).collect();
+    let mut buf = build_data(&data, bs);
+    // corrupt hash bits
+    buf[2] ^= 0x01;
+    assert!(decompress_with_limit(&buf, usize::MAX).is_err());
+}
+
+#[test]
+fn random_roundtrip() {
+    let bs = 5;
+    let data: Vec<u8> = (0u8..37).collect();
+    let out = compress(&data, bs);
+    let decoded = decompress_with_limit(&out, usize::MAX).unwrap();
+    assert_eq!(data, decoded);
+}


### PR DESCRIPTION
## Summary
- implement Telomere 24‑bit header with bit packing helpers
- compute SHA‑256 checksum bits and emit header in compressor
- parse the new header in decompressor and validate checksum
- update compression and decompression tests for new header
- add tests covering header encoding details and error cases

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6877275d326c83298df25b26f16b81eb