### PR TITLE
Implement hash_precompute main

### DIFF
--- a/src/bin/hash_precompute.rs
+++ b/src/bin/hash_precompute.rs
@@ -1,16 +1,19 @@
 use bincode;
-use inchworm::io_utils::{io_cli_error, simple_cli_error};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
+use telomere::io_utils::{io_cli_error, simple_cli_error};
 
-/// Entry written to the binary hash table file.
+/// 8-byte record stored in the hash table.
+///
+/// Each entry stores the first three bytes of the seed's SHA-256 digest,
+/// the seed length and the zero padded seed bytes.
 #[repr(C)]
-#[derive(Debug, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 struct HashEntry {
-    hash: [u8; 32],
+    hash_prefix: [u8; 3],
     seed_len: u8,
     seed: [u8; 4],
 }
@@ -23,57 +26,46 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let mut entries = Vec::<HashEntry>::new();
+
+    // Collect entries for all seed lengths.
+    for len in 1u8..=4 {
+        let count: u64 = 1u64 << (len * 8);
+        for i in 0..count {
+            let mut seed = [0u8; 4];
+            for b in 0..len {
+                seed[(len - 1 - b) as usize] = ((i >> (8 * b)) & 0xFF) as u8;
+            }
+
+            let digest = Sha256::digest(&seed[..len as usize]);
+            let mut prefix = [0u8; 3];
+            prefix.copy_from_slice(&digest[..3]);
+
+            entries.push(HashEntry {
+                hash_prefix: prefix,
+                seed_len: len,
+                seed,
+            });
+        }
+    }
+
+    // Sort by hash prefix.
+    entries.sort_unstable_by(|a, b| a.hash_prefix.cmp(&b.hash_prefix));
+
     let path = Path::new("hash_table.bin");
     let file = File::create(path).map_err(|e| io_cli_error("creating output file", path, e))?;
     let mut writer = BufWriter::new(file);
 
-    // Iterate over seed lengths 1, 2, and 3
-    for len in 1..=4 {
-        let max = match len {
-            1 => 1 << 8,
-            2 => 1 << 16,
-            3 => 1 << 24,
-            4 => 894_784_853, // 30 GB cap
-            _ => unreachable!(),
-        };
-        println!("Generating {}-byte seeds ({} total)...", len, max);
-
-        for i in 0..max {
-            let seed = match len {
-                1 => vec![(i & 0xFF) as u8],
-                2 => vec![(i >> 8) as u8, (i & 0xFF) as u8],
-                3 => vec![(i >> 16) as u8, ((i >> 8) & 0xFF) as u8, (i & 0xFF) as u8],
-                4 => vec![
-                    (i >> 24) as u8,
-                    (i >> 16) as u8,
-                    (i >> 8) as u8,
-                    (i & 0xFF) as u8,
-                ],
-                _ => unreachable!(),
-            };
-
-            // Compute SHA-256 of the seed
-            let out: [u8; 32] = Sha256::digest(&seed).into();
-            let mut padded_seed = [0u8; 4];
-            padded_seed[..len].copy_from_slice(&seed);
-
-            let entry = HashEntry {
-                hash: out,
-                seed_len: len as u8,
-                seed: padded_seed,
-            };
-
-            let serialized = bincode::serialize(&entry)
-                .map_err(|e| simple_cli_error(&format!("serialization failed: {e}")))?;
-            writer
-                .write_all(&serialized)
-                .map_err(|e| io_cli_error("writing output file", path, e))?;
-        }
+    for entry in entries {
+        let serialized = bincode::serialize(&entry)
+            .map_err(|e| simple_cli_error(&format!("serialization failed: {e}")))?;
+        writer
+            .write_all(&serialized)
+            .map_err(|e| io_cli_error("writing output file", path, e))?;
     }
 
     writer
         .flush()
         .map_err(|e| io_cli_error("writing output file", path, e))?;
-    println!("Hash table written to hash_table.bin");
     Ok(())
 }

--- a/src/bin/seed_table.rs
+++ b/src/bin/seed_table.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use inchworm::io_utils::io_cli_error;
 use sha2::{Digest, Sha256};
 use std::{
     collections::HashSet,
@@ -7,6 +6,7 @@ use std::{
     io::{BufRead, BufReader, BufWriter, Write},
     path::Path,
 };
+use telomere::io_utils::io_cli_error;
 
 #[derive(Parser)]
 struct Args {

--- a/tests/file_errors.rs
+++ b/tests/file_errors.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 #[test]
 fn invalid_extension_error() {
-    let exe = env!("CARGO_BIN_EXE_inchworm");
+    let exe = env!("CARGO_BIN_EXE_telomere");
     let dir = tempfile::tempdir().unwrap();
     let input = dir.path().join("input.txt");
     fs::write(&input, b"bad").unwrap();
@@ -17,7 +17,7 @@ fn invalid_extension_error() {
 
 #[test]
 fn truncated_file_error() {
-    let exe = env!("CARGO_BIN_EXE_inchworm");
+    let exe = env!("CARGO_BIN_EXE_telomere");
     let dir = tempfile::tempdir().unwrap();
     let input = dir.path().join("bad.tlmr");
     fs::write(&input, b"baddata").unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,26 +14,18 @@ fn cli_roundtrip() {
 
     let compress = Command::new(exe)
         .args([
-            "compress",
+            "c",
+            input.to_str().unwrap(),
+            compressed.to_str().unwrap(),
             "--block-size",
             "3",
-            "--input",
-            input.to_str().unwrap(),
-            "--output",
-            compressed.to_str().unwrap(),
         ])
         .output()
         .expect("failed to run compress");
     assert!(compress.status.success());
 
     let decompress = Command::new(exe)
-        .args([
-            "decompress",
-            "--input",
-            compressed.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-        ])
+        .args(["d", compressed.to_str().unwrap(), output.to_str().unwrap()])
         .output()
         .expect("failed to run decompress");
     assert!(decompress.status.success());


### PR DESCRIPTION
## Summary
- add HashEntry with truncated SHA-256 prefix
- generate and sort seeds, then write hash_table.bin
- fix crate paths in seed_table binary
- update integration and other tests for new binary name and CLI

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687734c889008329a895d2e399b11140