### PR TITLE
Generate 3‑byte seeds and optimize hash table writing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ serde_json = "1"
 bincode = "1"
 serde = { version = "1", features = ["derive"] }
 memmap2 = "0.5"
-bytemuck = "1"
 thiserror = "2.0.12"
 csv = "1"
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ to disk. When a seed is persisted, the library checks disk and memory
 consumption before appending the new entry. If the file would exceed configured
 limits or the system is low on memory, the operation aborts with an error.
 
-The default table path is `hash_table.bin` and entries are encoded with
-`bincode`.
+The default table path is `hash_table.bin` and entries are stored as fixed
+8-byte records. Precomputing 1-, 2-, and 3-byte seeds produces roughly 16.8
+million entries (~135 MB).
 
 ---
 

--- a/src/bin/hash_precompute.rs
+++ b/src/bin/hash_precompute.rs
@@ -1,4 +1,4 @@
-use bincode;
+use bytemuck::{Pod, Zeroable};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fs::File;
@@ -18,6 +18,9 @@ struct HashEntry {
     seed: [u8; 4],
 }
 
+unsafe impl Zeroable for HashEntry {}
+unsafe impl Pod for HashEntry {}
+
 fn main() {
     if let Err(e) = run() {
         eprintln!("Error: {e}");
@@ -28,8 +31,43 @@ fn main() {
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut entries = Vec::<HashEntry>::new();
 
-    // Only 1- and 2-byte seeds as requested
+    // Pre-allocate space for all entries. When including 3-byte seeds this
+    // amounts to roughly 135 MB of memory for 16,843,008 entries.
+    let generate_three_byte = true; // placeholder
+    let total: usize = (1u64 << 8 | 1u64 << 16) as usize
+        + if generate_three_byte {
+            (1u64 << 24) as usize
+        } else {
+            0
+        };
+    entries
+        .try_reserve_exact(total)
+        .map_err(|e| simple_cli_error(&format!("unable to reserve memory: {e}")))?;
+
+    // Generate all 1- and 2-byte seeds
     for len in 1u8..=2 {
+        let count: u64 = 1u64 << (len * 8);
+        for i in 0..count {
+            let mut seed = [0u8; 4];
+            for b in 0..len {
+                seed[(len - 1 - b) as usize] = ((i >> (8 * b)) & 0xFF) as u8;
+            }
+
+            let digest = Sha256::digest(&seed[..len as usize]);
+            let mut prefix = [0u8; 3];
+            prefix.copy_from_slice(&digest[..3]);
+
+            entries.push(HashEntry {
+                hash_prefix: prefix,
+                seed_len: len,
+                seed,
+            });
+        }
+    }
+
+    if generate_three_byte {
+        // Generating 3-byte seeds significantly increases memory usage.
+        let len = 3u8;
         let count: u64 = 1u64 << (len * 8);
         for i in 0..count {
             let mut seed = [0u8; 4];
@@ -53,20 +91,20 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     entries.sort_unstable_by(|a, b| a.hash_prefix.cmp(&b.hash_prefix));
 
     let path = Path::new("hash_table.bin");
+    // The resulting file is around 135 MB when 3-byte seeds are generated.
     let file = File::create(path).map_err(|e| io_cli_error("creating output file", path, e))?;
     let mut writer = BufWriter::new(file);
 
-    for entry in entries {
-        let serialized = bincode::serialize(&entry)
-            .map_err(|e| simple_cli_error(&format!("serialization failed: {e}")))?;
-        writer
-            .write_all(&serialized)
-            .map_err(|e| io_cli_error("writing output file", path, e))?;
-    }
+    // Write all entries at once using bytemuck for speed.
+    let bytes: &[u8] = bytemuck::cast_slice(&entries);
+    writer
+        .write_all(bytes)
+        .map_err(|e| io_cli_error("writing output file", path, e))?;
+    writer
+        .flush()
+        .map_err(|e| io_cli_error("flushing output file", path, e))?;
 
-    writer.flush().map_err(|e| io_cli_error("flushing output file", path, e))?;
-
-    println!("Done writing 1- and 2-byte seed hash table.");
+    println!("Done writing seed hash table ({} entries).", entries.len());
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod tlmr;
 // Gloss table support has been removed for the MVP.  The original
 // implementation used precomputed decompressed strings to accelerate
 // seed matching.  Future versions may reintroduce a `gloss` module.
+mod hash_reader;
 mod header;
 pub mod io_utils;
 mod live_window;
@@ -20,7 +21,6 @@ mod path;
 mod seed_detect;
 mod seed_logger;
 mod sha_cache;
-mod hash_reader;
 mod stats;
 
 pub use block::{
@@ -28,14 +28,13 @@ pub use block::{
     prune_branches, run_all_passes, split_into_blocks, Block, BlockChange, BlockTable,
     BranchStatus,
 };
-pub use hash_reader::lookup_seed;
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
 pub use compress::{compress, compress_block, TruncHashTable};
 pub use compress_stats::{write_stats_csv, CompressionStats};
 pub use file_header::{decode_file_header, encode_file_header};
+pub use hash_reader::lookup_seed;
 pub use header::{decode_header, encode_header, Header, HeaderError};
 pub use io_utils::*;
-pub use tlmr::{decode_tlmr_header, encode_tlmr_header, truncated_hash, TlmrError, TlmrHeader};
 pub use live_window::{print_window, LiveStats};
 pub use path::*;
 pub use seed_detect::{detect_seed_matches, MatchRecord};
@@ -43,8 +42,8 @@ pub use seed_logger::{
     log_seed, log_seed_to, resume_seed_index, resume_seed_index_from, HashEntry, ResourceLimits,
 };
 pub use sha_cache::*;
-pub use hash_reader::lookup_seed;
 pub use stats::Stats;
+pub use tlmr::{decode_tlmr_header, encode_tlmr_header, truncated_hash, TlmrError, TlmrHeader};
 
 pub fn print_compression_status(original: usize, compressed: usize) {
     let ratio = 100.0 * (1.0 - compressed as f64 / original as f64);
@@ -85,7 +84,7 @@ pub fn decompress_region_with_limit(
 ///
 /// Files begin with a 3-byte Telomere header describing protocol version,
 /// block size, last block size and a truncated output hash. Each subsequent
-/// region is prefixed with a normal header. 
+/// region is prefixed with a normal header.
 pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, TlmrError> {
     if input.len() < 3 {
         return Err(TlmrError::TooShort);


### PR DESCRIPTION
## Summary
- generate 3‑byte seeds in `hash_precompute`
- preallocate vector with error handling
- write entire table using `bytemuck::cast_slice`
- update docs on hash table format
- remove duplicate `lookup_seed` re-export

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687823895b20832992d2350a18780ac8