### PR TITLE
Improve telomere CLI with clap subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ serde_json = "1"
 bincode = "1"
 serde = { version = "1", features = ["derive"] }
 memmap2 = "0.5"
-bytemuck = "1"
 thiserror = "2.0.12"
 csv = "1"
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ compressed units, enabling recursive compaction. Unmatched blocks are emitted as
 literal passthroughs, using reserved header codes—never as raw bytes.
 
 Telomere exposes a simple command line interface built on top of these
-primitives.  The binary is invoked with a mode (`c` for compress or `d` for
-decompress) followed by input and output file paths.  Additional flags tweak
-runtime behaviour:
+primitives. Compression and decompression are invoked via subcommands –
+`compress` (alias `c`) and `decompress` (alias `d`). Input and output paths may
+be provided positionally or with the `--input`/`--output` flags. Additional
+flags tweak runtime behaviour:
 
 ```
-USAGE: telomere [c|d] <input> <output> [--block-size N] [--status] [--json] [--dry-run]
+USAGE:
+    telomere compress [OPTIONS] [INPUT] [OUTPUT]
+    telomere decompress [OPTIONS] [INPUT] [OUTPUT]
 
 FLAGS:
     --block-size N   size of each compression block (default 3)
@@ -28,10 +31,10 @@ The following demonstrates a typical round‑trip using default settings:
 
 ```
 # Compress a file
-cargo run --release -- c input.bin output.tlmr --block-size 4 --status
+cargo run --release -- compress -i input.bin -o output.tlmr --block-size 4 --status
 
 # Decompress back to the original bytes
-cargo run --release -- d output.tlmr restored.bin
+cargo run --release -- decompress output.tlmr restored.bin
 ```
 
 ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 //! Telomere command line entry point.
 //!
-//! Compression and decompression are selected via the first positional
-//! argument.  This binary is intentionally thin and merely forwards to the
+//! Compression and decompression are exposed as subcommands. This binary
+//! intentionally performs minimal argument handling before delegating to the
 //! library APIs found in this crate.
 
-use std::{env, fs, path::Path, time::Instant};
+use clap::{ArgGroup, Args, Parser, Subcommand};
+use std::{fs, path::PathBuf, time::Instant};
 use telomere::{
     compress, decompress_with_limit,
     io_utils::{extension_error, io_cli_error, simple_cli_error},
@@ -18,68 +19,22 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 4 {
-        eprintln!(
-            "Usage: {} [c|d] <input> <output> [--block-size N] [--status] [--json] [--dry-run] [--force]",
-            args[0]
-        );
-        return Err(simple_cli_error("Insufficient arguments").into());
-    }
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Compress(mut args) => {
+            let input_path = args.input.take().or(args.input_pos).unwrap();
+            let output_path = args.output.take().or(args.output_pos).unwrap();
+            let data = fs::read(&input_path)
+                .map_err(|e| io_cli_error("opening input file", &input_path, e))?;
 
-    let mut block_size = 3_usize;
-    let mut show_status = false;
-    let mut json_out = false;
-    let mut dry_run = false;
-    let mut force = false;
-
-    let mut i = 4;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--block-size" => {
-                block_size = args.get(i + 1)
-                    .ok_or_else(|| simple_cli_error("Missing value for --block-size"))?
-                    .parse()
-                    .map_err(|_| simple_cli_error("Invalid block size"))?;
-                i += 2;
-            }
-            "--status" => {
-                show_status = true;
-                i += 1;
-            }
-            "--json" => {
-                json_out = true;
-                i += 1;
-            }
-            "--dry-run" => {
-                dry_run = true;
-                i += 1;
-            }
-            "--force" => {
-                force = true;
-                i += 1;
-            }
-            flag => {
-                return Err(simple_cli_error(&format!("Unknown flag: {}", flag)).into());
-            }
-        }
-    }
-
-    let input_path = Path::new(&args[2]);
-    let output_path = Path::new(&args[3]);
-    let data = fs::read(input_path)
-        .map_err(|e| io_cli_error("opening input file", input_path, e))?;
-
-    match args[1].as_str() {
-        "c" => {
             let start_time = Instant::now();
-            let out = compress(&data, block_size);
+            let out = compress(&data, args.block_size);
 
             if out.is_empty() {
                 return Err(simple_cli_error("compress() returned no data").into());
             }
 
-            if output_path.exists() && !force && !dry_run {
+            if output_path.exists() && !args.force && !args.dry_run {
                 return Err(simple_cli_error(&format!(
                     "Error: output file {} already exists (use --force to overwrite)",
                     output_path.display()
@@ -87,9 +42,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .into());
             }
 
-            if !dry_run {
-                fs::write(output_path, &out)
-                    .map_err(|e| io_cli_error("writing output file", output_path, e))?;
+            if !args.dry_run {
+                fs::write(&output_path, &out)
+                    .map_err(|e| io_cli_error("writing output file", &output_path, e))?;
                 eprintln!("✅ Wrote compressed output to {:?}", output_path);
             } else {
                 eprintln!("(dry run) skipping file write");
@@ -100,48 +55,107 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let percent = 100.0 * (1.0 - (compressed_len as f64 / raw_len as f64));
             let elapsed = start_time.elapsed();
 
-            if json_out {
+            if args.json {
                 let out_json = serde_json::json!({
                     "input_bytes": raw_len,
                     "compressed_bytes": compressed_len,
                     "elapsed_ms": elapsed.as_millis(),
                 });
                 println!("{}", serde_json::to_string_pretty(&out_json).unwrap());
-            } else if show_status {
+            } else if args.status {
                 eprintln!("Compressed {:.2}% in {:.2?}", percent, elapsed);
             }
         }
-
-        "d" => {
+        Command::Decompress(mut args) => {
+            let input_path = args.input.take().or(args.input_pos).unwrap();
+            let output_path = args.output.take().or(args.output_pos).unwrap();
             if input_path
                 .extension()
                 .and_then(|s| s.to_str())
                 .map_or(true, |ext| ext.to_ascii_lowercase() != "tlmr")
             {
-                return Err(extension_error(input_path).into());
+                return Err(extension_error(&input_path).into());
             }
-            if output_path.exists() && !force {
+            if output_path.exists() && !args.force {
                 return Err(simple_cli_error(&format!(
                     "Error: output file {} already exists (use --force to overwrite)",
                     output_path.display()
                 ))
                 .into());
             }
+            let data = fs::read(&input_path)
+                .map_err(|e| io_cli_error("opening input file", &input_path, e))?;
             let decompressed = decompress_with_limit(&data, usize::MAX)
                 .map_err(|e| simple_cli_error(&format!("decompression failed: {e}")))?;
-            if !dry_run {
-                fs::write(output_path, decompressed)
-                    .map_err(|e| io_cli_error("writing output file", output_path, e))?;
+            if !args.dry_run {
+                fs::write(&output_path, decompressed)
+                    .map_err(|e| io_cli_error("writing output file", &output_path, e))?;
                 eprintln!("✅ Wrote decompressed output to {:?}", output_path);
             } else {
                 eprintln!("(dry run) skipping file write");
             }
         }
-
-        mode => {
-            return Err(simple_cli_error(&format!("Unknown mode: {}", mode)).into());
-        }
     }
 
     Ok(())
+}
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Compress a file
+    #[command(alias = "c")]
+    Compress(ActionArgs),
+    /// Decompress a file
+    #[command(alias = "d")]
+    Decompress(ActionArgs),
+}
+
+#[derive(Args)]
+#[command(
+    group(
+        ArgGroup::new("input_src")
+            .required(true)
+            .args(["input", "input_pos"]),
+    ),
+    group(
+        ArgGroup::new("output_dst")
+            .required(true)
+            .args(["output", "output_pos"]),
+    )
+)]
+struct ActionArgs {
+    /// Input file path
+    #[arg(short, long, value_name = "FILE")]
+    input: Option<PathBuf>,
+    /// Output file path
+    #[arg(short, long, value_name = "FILE")]
+    output: Option<PathBuf>,
+    /// Input file path (positional)
+    #[arg(index = 1, value_name = "INPUT", conflicts_with = "input")]
+    input_pos: Option<PathBuf>,
+    /// Output file path (positional)
+    #[arg(index = 2, value_name = "OUTPUT", conflicts_with = "output")]
+    output_pos: Option<PathBuf>,
+    /// Compression block size
+    #[arg(long, default_value_t = 3)]
+    block_size: usize,
+    /// Print a short progress line for every block
+    #[arg(long)]
+    status: bool,
+    /// Emit a JSON summary after completion
+    #[arg(long)]
+    json: bool,
+    /// Perform the operation but skip writing the output file
+    #[arg(long)]
+    dry_run: bool,
+    /// Overwrite the output file if it already exists
+    #[arg(long)]
+    force: bool,
 }


### PR DESCRIPTION
## Summary
- support `compress`/`decompress` subcommands with short aliases
- allow input/output paths via `--input`/`--output` or positionals
- document the new usage in the README
- remove duplicate dependency entry in `Cargo.toml`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68782394bcc88329bcc56ea9e086fb1a