### PR TITLE
Add exhaustive dynamic header tests

### DIFF
--- a/tests/dtoggle_header.rs
+++ b/tests/dtoggle_header.rs
@@ -1,0 +1,172 @@
+use telomere::{encode_header, decode_header, Header};
+
+// Helper to pack bits big-endian identical to the library implementation
+fn pack_bits(bits: &[bool]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut byte = 0u8;
+    let mut used = 0u8;
+    for &b in bits {
+        byte = (byte << 1) | b as u8;
+        used += 1;
+        if used == 8 {
+            out.push(byte);
+            byte = 0;
+            used = 0;
+        }
+    }
+    if used > 0 {
+        byte <<= 8 - used;
+        out.push(byte);
+    }
+    if out.is_empty() {
+        out.push(0);
+    }
+    out
+}
+
+// Reproduce the EVQL bitstream for a seed index
+fn evql_bits(value: usize) -> Vec<bool> {
+    let mut width = 1usize;
+    let mut n = 0usize;
+    while value >= (1usize << width) {
+        width <<= 1;
+        n += 1;
+    }
+    let mut bits = vec![true; n];
+    bits.push(false);
+    for i in (0..width).rev() {
+        bits.push(((value >> i) & 1) != 0);
+    }
+    bits
+}
+
+#[test]
+fn arity_bit_patterns() {
+    // Expected toggle patterns for arity values 1-7
+    // Based on protocol table:
+    // 1 -> 0
+    // 2 -> 1 00
+    // 3 -> 1 01
+    // 4 -> 1 10
+    // 5 -> 1 11 000
+    // 6 -> 1 11 001
+    // 7 -> 1 11 010
+    let patterns: &[(usize, &[bool])] = &[
+        (1, &[false]),
+        (2, &[true, false, false]),
+        (3, &[true, false, true]),
+        (4, &[true, true, false]),
+        (5, &[true, true, true, false, false, false]),
+        (6, &[true, true, true, false, false, true]),
+        (7, &[true, true, true, false, true, false]),
+    ];
+
+    let small_seed = 3usize;
+    let large_seed = 1_000_000usize;
+
+    for &(arity, bits) in patterns {
+        // Small seed index pattern
+        let mut expected = bits.to_vec();
+        expected.extend(evql_bits(small_seed));
+        let enc = encode_header(&Header::Standard { seed_index: small_seed, arity });
+        assert_eq!(enc, pack_bits(&expected), "arity {} small index", arity);
+        let (decoded, _) = decode_header(&enc).unwrap();
+        assert_eq!(decoded, Header::Standard { seed_index: small_seed, arity });
+
+        // Large seed index pattern
+        let mut expected_big = bits.to_vec();
+        expected_big.extend(evql_bits(large_seed));
+        let enc_big = encode_header(&Header::Standard { seed_index: large_seed, arity });
+        assert_eq!(enc_big, pack_bits(&expected_big), "arity {} large index", arity);
+        let (decoded_big, _) = decode_header(&enc_big).unwrap();
+        assert_eq!(decoded_big, Header::Standard { seed_index: large_seed, arity });
+    }
+}
+
+#[test]
+fn marker_bit_patterns() {
+    // Marker headers do not include a seed index
+    // penultimate markers:
+    // arity 1 -> 1 11 011
+    // arity 2 -> 1 11 100
+    // arity 3 -> 1 11 101
+    // literal     -> 1 11 110
+    // literal last-> 1 11 111
+    let literal = pack_bits(&[true, true, true, true, true, false]);
+    let final_block = pack_bits(&[true, true, true, true, true, true]);
+
+    assert_eq!(encode_header(&Header::Penultimate { seed_index: 0, arity: 1 }), {
+        let mut bits = vec![true, true, true, false, true, true];
+        bits.extend(evql_bits(0));
+        pack_bits(&bits)
+    });
+    assert_eq!(encode_header(&Header::Penultimate { seed_index: 5, arity: 2 }), {
+        let mut bits = vec![true, true, true, true, false, false];
+        bits.extend(evql_bits(5));
+        pack_bits(&bits)
+    });
+    assert_eq!(encode_header(&Header::Penultimate { seed_index: 7, arity: 3 }), {
+        let mut bits = vec![true, true, true, true, false, true];
+        bits.extend(evql_bits(7));
+        pack_bits(&bits)
+    });
+    assert_eq!(encode_header(&Header::Literal), literal);
+    assert_eq!(encode_header(&Header::LiteralLast), final_block);
+
+    // Decode roundtrips
+    for h in [
+        Header::Penultimate { seed_index: 0, arity: 1 },
+        Header::Penultimate { seed_index: 5, arity: 2 },
+        Header::Penultimate { seed_index: 7, arity: 3 },
+        Header::Literal,
+        Header::LiteralLast,
+    ] {
+        let enc = encode_header(&h);
+        let (dec, _) = decode_header(&enc).unwrap();
+        assert_eq!(dec, h);
+    }
+}
+
+#[test]
+fn seed_index_lengths() {
+    // EVQL expected bit lengths for various seed indices
+    // value -> total bits used by EVQL
+    // 0 -> 2, 1 -> 2, 2 -> 4, 3 -> 4, 15 -> 7,
+    // 16 -> 12, 255 -> 12, 256 -> 21, 1023 -> 21, 1_000_000 -> 38
+    let cases = [
+        (0usize, 2usize),
+        (1, 2),
+        (2, 4),
+        (3, 4),
+        (15, 7),
+        (16, 12),
+        (255, 12),
+        (256, 21),
+        (1023, 21),
+        (1_000_000, 38),
+    ];
+
+    for &(seed, expected_bits) in &cases {
+        let bits = evql_bits(seed);
+        assert_eq!(bits.len(), expected_bits, "seed {}", seed);
+        let arity_bits = [false]; // arity 1 -> single zero bit
+        let mut all = arity_bits.to_vec();
+        all.extend(bits.clone());
+        let enc = encode_header(&Header::Standard { seed_index: seed, arity: 1 });
+        assert_eq!(enc, pack_bits(&all));
+        let (dec, used) = decode_header(&enc).unwrap();
+        assert_eq!(dec, Header::Standard { seed_index: seed, arity: 1 });
+        assert_eq!(used, all.len(), "bit length mismatch for seed {}", seed);
+    }
+}
+
+#[test]
+fn truncated_headers_fail() {
+    // Truncate a valid header so not all bits are available
+    let full = encode_header(&Header::Standard { seed_index: 1, arity: 2 });
+    assert!(decode_header(&full[..0]).is_err());
+
+    // Truncated literal marker
+    let lit = encode_header(&Header::Literal);
+    assert!(decode_header(&lit[..0]).is_err());
+}


### PR DESCRIPTION
## Summary
- add `dtoggle_header.rs` to exhaustively validate Telomere header bit patterns
- verify toggle bits for arity 1–7 with small and large seed indices
- check marker encodings and EVQL bit lengths
- ensure truncated headers fail decoding

## Testing
- `cargo test`
- `cargo test --test dtoggle_header`

------
https://chatgpt.com/codex/tasks/task_e_687831e10a5c83298c6827633fa7065b