### PR TITLE
Implement multi-pass compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ USAGE:
 
 FLAGS:
     --block-size N   size of each compression block (default 3)
+    --passes N       maximum compression passes (default 10)
     --status         print a short progress line for every block
     --json           emit a JSON summary after completion
     --dry-run        perform compression but skip writing the output file
@@ -115,3 +116,11 @@ Decoders verify the hash after reconstructing a batch to detect corruption.
 - ✅ Deterministic compression and literal passthrough format complete
 - ✅ Round-trip identity supported
 - 🔜 Seed-driven decoding (G-based) in development
+
+## Telomere Protocol Compliance Notes
+
+The compressed output contains only headers and deterministic seed references.
+Any literal bytes are wrapped in a `Literal` header and expected to vanish as
+multi-pass compression converges. Stopping early may leave such sections in the
+stream, which is allowed but suboptimal. No entropy coding is applied at any
+stage, adhering to the stateless design described in the whitepaper.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use block::{
 };
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
 pub use candidate::{prune_candidates, Block as CandidateBlock, Candidate};
-pub use compress::{compress, compress_block, TruncHashTable};
+pub use compress::{compress, compress_block, compress_multi_pass, TruncHashTable};
 pub use compress_stats::{write_stats_csv, CompressionStats};
 pub use file_header::{decode_file_header, encode_file_header};
 pub use hash_reader::lookup_seed;


### PR DESCRIPTION
## Summary
- add `compress_multi_pass` and integrate into CLI
- support `--passes` CLI argument
- document Telomere protocol compliance

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687835ba45c88329af551ce8f7c33eed