### PR TITLE
Add doc lint harness and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ primitives. Compression and decompression are invoked via subcommands –
 be provided positionally or with the `--input`/`--output` flags. Additional
 flags tweak runtime behaviour:
 
-```
+```text
 USAGE:
     telomere compress [OPTIONS] [INPUT] [OUTPUT]
     telomere decompress [OPTIONS] [INPUT] [OUTPUT]
@@ -25,11 +25,11 @@ FLAGS:
     --dry-run        perform compression but skip writing the output file
 ```
 
-### Usage Example
+## Usage Example
 
 The following demonstrates a typical round‑trip using default settings:
 
-```
+```bash
 # Compress a file
 cargo run --release -- compress -i input.bin -o output.tlmr --block-size 4 --status
 
@@ -61,12 +61,13 @@ All files begin with an EVQL-encoded file header describing:
 - The fixed block size
 
 Every block after that is preceded by a standard compressed block header:
+
 - **Seed index**
 - **Arity**
 
 The `arity` field encodes both compression span and literal passthrough signals:
 
-### Reserved Arity Values for Literal Passthrough:
+### Reserved Arity Values for Literal Passthrough
 
 - `29` → one literal block  
 - `30` → two literal blocks  
@@ -74,6 +75,7 @@ The `arity` field encodes both compression span and literal passthrough signals:
 - `32` → final tail (shorter than full block)
 
 These literal codes are used in place of escape markers or raw bytes:
+
 - The decoder reads the arity.
 - If it is `29`–`31`, it copies that number of literal blocks directly.
 - If it is `32`, it copies the remaining tail bytes (less than `block_size`).
@@ -87,7 +89,7 @@ Telomere files are organized into small batches of up to three blocks.  Each
 batch starts with a fixed three‑byte header followed by one or more standard
 block headers and the associated data.  Conceptually this looks as follows:
 
-```
+```text
 ┌──────────────┬───────────────────────────────────┐
 │ 3‑byte batch │ block header → block data → ...   │
 │ header       │                                   │
@@ -107,6 +109,18 @@ The batch header packs a small amount of metadata into three bytes:
 - **Bits 8‑23** – truncated SHA‑256 of the batch output for quick sanity checks
 
 Decoders verify the hash after reconstructing a batch to detect corruption.
+
+---
+
+## Telomere Protocol Compliance Notes
+
+Telomere maintains a **stateless** design aside from the optional seed table.
+The format never emits **raw data** directly; literal regions use reserved arity
+codes as a **literal fallback** path. Every file header records the format
+**version** and fixed **block size**. There is no entropy or statistical coding
+involved—compression relies purely on search. The **literal header logic** is
+intentionally simple, and recursive batching ensures eventual **convergence** of
+nested segments as a recursive convergence goal.
 
 ---
 

--- a/scripts/doc_lint.py
+++ b/scripts/doc_lint.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def check_cmd(cmd: str) -> bool:
+    return subprocess.run(['which', cmd], capture_output=True).returncode == 0
+
+if not check_cmd('markdownlint'):
+    print('ERROR: markdownlint not found in PATH. Install with `npm install -g markdownlint-cli`')
+    sys.exit(1)
+
+# Files to lint
+docs = [Path('README.md')]
+
+# Run markdownlint
+lint_cmd = ['markdownlint'] + [str(d) for d in docs]
+print('Running markdownlint...')
+mdproc = subprocess.run(lint_cmd, capture_output=True, text=True)
+md_output = mdproc.stdout + mdproc.stderr
+md_warnings = [line for line in md_output.strip().splitlines() if line]
+if md_output:
+    print(md_output)
+
+# Required section and field checks
+checks = {
+    'Protocol Compliance Notes': 'protocol compliance notes',
+    'no raw data': 'raw data',
+    'literal fallback': 'literal fallback',
+    'stateless': 'stateless',
+    'version': 'version',
+    'block size': 'block size',
+    'literal header logic': 'literal header logic',
+    'entropy/statistical coding absence': 'entropy',
+    'recursive convergence goal': 'recursive convergence goal',
+}
+
+missing = []
+for doc in docs:
+    text = doc.read_text().lower()
+    for label, phrase in checks.items():
+        if phrase.lower() not in text:
+            missing.append(f'{doc}: missing {label}')
+
+if missing:
+    for m in missing:
+        print('WARNING:', m)
+
+print('Doc lint summary:')
+print(f'  markdownlint issues: {len(md_warnings)}')
+print(f'  missing fields: {len(missing)}')
+
+if md_warnings or missing:
+    sys.exit(1)

--- a/tests/doc_lint.rs
+++ b/tests/doc_lint.rs
@@ -1,0 +1,10 @@
+use std::process::Command;
+
+#[test]
+fn markdown_hygiene() {
+    let status = Command::new("python3")
+        .arg("scripts/doc_lint.py")
+        .status()
+        .expect("failed to run doc_lint script");
+    assert!(status.success());
+}


### PR DESCRIPTION
## Summary
- enforce Markdown hygiene with new `doc_lint.py` script
- check README for required protocol compliance notes and keywords
- add a regression test to run the linter
- clean README formatting and add Protocol Compliance Notes section

## Testing
- `cargo test --quiet`
- `python3 scripts/doc_lint.py`


------
https://chatgpt.com/codex/tasks/task_e_6878365b05688329b76825f0a7d2dff2