### PR TITLE
Implement deterministic seed enumeration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ slice_seed_table.rs
 src/bin/seed_table.rs
 !src/bin/gloss_dump.rs
 !src/bin/block_histogram.rs
+!src/seed_enum.rs
+!tests/index_to_seed.rs
 seed_table.csv
 run_table.bat
 table_24.csv

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod live_window;
 mod path;
 mod seed_detect;
 mod seed_logger;
+mod seed_enum;
 mod sha_cache;
 mod stats;
 
@@ -43,6 +44,7 @@ pub use seed_detect::{detect_seed_matches, MatchRecord};
 pub use seed_logger::{
     log_seed, log_seed_to, resume_seed_index, resume_seed_index_from, HashEntry, ResourceLimits,
 };
+pub use seed_enum::index_to_seed;
 pub use sha_cache::*;
 pub use stats::Stats;
 pub use tlmr::{decode_tlmr_header, encode_tlmr_header, truncated_hash, TlmrError, TlmrHeader};

--- a/src/seed_enum.rs
+++ b/src/seed_enum.rs
@@ -1,0 +1,29 @@
+/// Utilities for deterministic enumeration of variable-length seeds.
+///
+/// Seeds are enumerated in big-endian order by length. All 1-byte
+/// sequences come first, followed by all 2-byte sequences, then 3-byte
+/// sequences, and so on. `index_to_seed` reconstructs the canonical seed
+/// bytes for a given index.
+
+/// Returns the canonical variable-length seed bytes for the given index.
+/// - All 1-byte seeds come first (indices 0..=255)
+/// - All 2-byte seeds next (indices 256..=65535+255)
+/// - All 3-byte seeds after that, etc.
+/// Supports up to `max_seed_len` bytes.
+pub fn index_to_seed(idx: usize, max_seed_len: usize) -> Vec<u8> {
+    let mut total: u128 = 0;
+    let target = idx as u128;
+    for len in 1..=max_seed_len {
+        let count: u128 = 1u128 << (8 * len);
+        if target < total + count {
+            let offset = target - total;
+            let mut out = vec![0u8; len];
+            for i in 0..len {
+                out[len - 1 - i] = ((offset >> (8 * i)) & 0xFF) as u8;
+            }
+            return out;
+        }
+        total += count;
+    }
+    panic!("index out of range");
+}

--- a/tests/index_to_seed.rs
+++ b/tests/index_to_seed.rs
@@ -1,0 +1,12 @@
+use telomere::index_to_seed;
+
+#[test]
+fn basic_indices() {
+    assert_eq!(index_to_seed(0, 4), vec![0x00]);
+    assert_eq!(index_to_seed(1, 4), vec![0x01]);
+    assert_eq!(index_to_seed(255, 4), vec![0xFF]);
+    assert_eq!(index_to_seed(256, 4), vec![0x00, 0x00]);
+    assert_eq!(index_to_seed(257, 4), vec![0x00, 0x01]);
+    assert_eq!(index_to_seed(65791, 4), vec![0xFF, 0xFF]);
+    assert_eq!(index_to_seed(65792, 4), vec![0x00, 0x00, 0x00]);
+}


### PR DESCRIPTION
## Summary
- implement `index_to_seed` for mapping indices back to seed bytes
- expose `index_to_seed` in crate API
- add tests for the new function
- allow these new Rust files to be tracked

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6879288239888329a9ac9cc5ae0071a5