### PR TITLE
Implement July 2025 header scheme

### DIFF
--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -111,7 +111,7 @@ fn passthrough_final_tail() {
 fn unsupported_header_fails() {
     let block_size = 3;
     // Use a non-literal header (standard compressed, not supported here)
-    let header = encode_header(&Header::Standard { seed_index: 1, arity: 2 });
+    let header = encode_header(&Header::Standard { seed_index: 1, arity: 3 });
     let literal = vec![0u8; block_size];
     let tlmr = encode_tlmr_header(&TlmrHeader {
         version: 0,

--- a/tests/header_tests.rs
+++ b/tests/header_tests.rs
@@ -4,15 +4,9 @@ use telomere::{Header, encode_header, decode_header};
 fn header_roundtrip_across_ranges() {
     let cases = vec![
         Header::Standard { seed_index: 0, arity: 1 },
-        Header::Standard { seed_index: 1, arity: 2 },
-        Header::Standard { seed_index: 2, arity: 3 },
-        Header::Standard { seed_index: 3, arity: 4 },
-        Header::Standard { seed_index: 4, arity: 5 },
-        Header::Standard { seed_index: 5, arity: 6 },
-        Header::Standard { seed_index: 6, arity: 7 },
-        Header::Penultimate { seed_index: 7, arity: 1 },
-        Header::Penultimate { seed_index: 8, arity: 2 },
-        Header::Penultimate { seed_index: 9, arity: 3 },
+        Header::Standard { seed_index: 1, arity: 3 },
+        Header::Standard { seed_index: 2, arity: 4 },
+        Header::Standard { seed_index: 3, arity: 10 },
         Header::Literal,
         Header::LiteralLast,
     ];


### PR DESCRIPTION
## Summary
- update header encoding to use the arity‑2 terminal design
- drop penultimate header handling
- recognise `LiteralLast` with a dedicated marker
- adjust tests for new bit patterns

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6879bc230fec83299d4ae76175cf5765