### PR TITLE
Introduce TelomereError and unify error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ src/bin/seed_table.rs
 !src/bin/block_histogram.rs
 !src/bin/compressor.rs
 !src/bin/decompressor.rs
+!src/error.rs
 !src/seed_index.rs
 !tests/index_to_seed.rs
 !tests/compressor_cli.rs

--- a/src/bin/compressor.rs
+++ b/src/bin/compressor.rs
@@ -32,7 +32,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let data =
         fs::read(&args.input).map_err(|e| io_cli_error("reading input file", &args.input, e))?;
-    let compressed = compress(&data, args.block_size);
+    let compressed = compress(&data, args.block_size)
+        .map_err(|e| simple_cli_error(&format!("compression failed: {e}")))?;
 
     if args.test {
         let decompressed = decompress_with_limit(&compressed, usize::MAX)

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -10,7 +10,7 @@
 use crate::compress_stats::CompressionStats;
 use crate::header::{encode_header, Header};
 use crate::tlmr::{encode_tlmr_header, truncated_hash, TlmrHeader};
-use crate::index_to_seed;
+use crate::{index_to_seed, TelomereError};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -88,22 +88,22 @@ fn expand_seed(seed: &[u8], len: usize) -> Vec<u8> {
 }
 
 /// Find a seed index whose SHA-256 expansion matches the slice.
-fn find_seed_match(slice: &[u8], max_seed_len: usize) -> Option<usize> {
+fn find_seed_match(slice: &[u8], max_seed_len: usize) -> Result<Option<usize>, TelomereError> {
     let mut limit = 0usize;
     for len in 1..=max_seed_len {
         limit += 1usize << (8 * len);
     }
     for idx in 0..limit {
-        let seed = index_to_seed(idx, max_seed_len);
+        let seed = index_to_seed(idx, max_seed_len)?;
         if expand_seed(&seed, slice.len()) == slice {
-            return Some(idx);
+            return Ok(Some(idx));
         }
     }
-    None
+    Ok(None)
 }
 
 /// Compress the input using brute-force seed search with optional bundling.
-pub fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
+pub fn compress(data: &[u8], block_size: usize) -> Result<Vec<u8>, TelomereError> {
     let last_block = if data.is_empty() { 0 } else { (data.len() - 1) % block_size + 1 };
     let hash = truncated_hash(data);
     let header_bytes = encode_tlmr_header(&TlmrHeader {
@@ -120,7 +120,7 @@ pub fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
     while offset < data.len() {
         let remaining = data.len() - offset;
         if remaining < block_size {
-            out.extend_from_slice(&encode_header(&Header::LiteralLast));
+            out.extend_from_slice(&encode_header(&Header::LiteralLast)?);
             out.extend_from_slice(&data[offset..]);
             break;
         }
@@ -130,9 +130,9 @@ pub fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
         for arity in (1..=max_bundle).rev() {
             let span_len = arity * block_size;
             let slice = &data[offset..offset + span_len];
-            if let Some(seed_idx) = find_seed_match(slice, max_seed_len) {
+            if let Some(seed_idx) = find_seed_match(slice, max_seed_len)? {
                 let header = Header::Standard { seed_index: seed_idx, arity };
-                let hbytes = encode_header(&header);
+                let hbytes = encode_header(&header)?;
                 if hbytes.len() < span_len {
                     out.extend_from_slice(&hbytes);
                     offset += span_len;
@@ -144,13 +144,13 @@ pub fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
 
         if !matched {
             let header = if remaining == block_size { Header::LiteralLast } else { Header::Literal };
-            out.extend_from_slice(&encode_header(&header));
+            out.extend_from_slice(&encode_header(&header)?);
             out.extend_from_slice(&data[offset..offset + block_size]);
             offset += block_size;
         }
     }
 
-    out
+    Ok(out)
 }
 
 /// Perform multi-pass compression. After the first pass, the result is
@@ -160,15 +160,15 @@ pub fn compress_multi_pass(
     data: &[u8],
     block_size: usize,
     max_passes: usize,
-) -> Result<Vec<u8>, crate::tlmr::TlmrError> {
-    let mut compressed = compress(data, block_size);
+) -> Result<Vec<u8>, TelomereError> {
+    let mut compressed = compress(data, block_size)?;
     if max_passes <= 1 {
         return Ok(compressed);
     }
     let mut prev_size = compressed.len();
     for pass in 2..=max_passes {
         let decompressed = crate::decompress_with_limit(&compressed, usize::MAX)?;
-        let new_compressed = compress(&decompressed, block_size);
+        let new_compressed = compress(&decompressed, block_size)?;
         if new_compressed.len() < prev_size {
             eprintln!(
                 "Pass {}: size {} -> {}",
@@ -190,24 +190,24 @@ pub fn compress_block(
     input: &[u8],
     block_size: usize,
     mut stats: Option<&mut CompressionStats>,
-) -> Option<(Header, usize)> {
+) -> Result<Option<(Header, usize)>, TelomereError> {
     if input.len() < block_size {
-        return None;
+        return Ok(None);
     }
     if let Some(s) = stats.as_mut() {
         s.tick_block();
     }
 
     let slice = &input[..block_size];
-    if let Some(seed_idx) = find_seed_match(slice, 2) {
+    if let Some(seed_idx) = find_seed_match(slice, 2)? {
         let header = Header::Standard { seed_index: seed_idx, arity: 1 };
-        let hbytes = encode_header(&header);
+        let hbytes = encode_header(&header)?;
         if hbytes.len() < block_size {
             if let Some(s) = stats.as_mut() {
                 s.maybe_log(slice, slice, true);
                 s.log_match(true, 1);
             }
-            return Some((header, block_size));
+            return Ok(Some((header, block_size)));
         }
     }
 
@@ -216,5 +216,5 @@ pub fn compress_block(
         s.log_match(false, 1);
     }
 
-    Some((Header::Literal, block_size))
+    Ok(Some((Header::Literal, block_size)))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum TelomereError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Decode error: {0}")]
+    Decode(String),
+    #[error("Hashing error: {0}")]
+    Hash(String),
+    #[error("Config error: {0}")]
+    Config(String),
+    #[error("Other: {0}")]
+    Other(String),
+}

--- a/src/header.rs
+++ b/src/header.rs
@@ -18,6 +18,7 @@
 //! the truncated hash stored in the surrounding batch header.
 
 use thiserror::Error;
+use crate::TelomereError;
 
 /**
 Telomere headers use dynamic toggles (dToggles) for the arity field and
@@ -58,17 +59,19 @@ pub enum HeaderError {
 }
 
 /// Encode a Telomere header and return packed bytes.
-pub fn encode_header(h: &Header) -> Vec<u8> {
+pub fn encode_header(h: &Header) -> Result<Vec<u8>, TelomereError> {
     let mut bits = Vec::new();
     match *h {
         Header::Standard { seed_index, arity } => {
-            bits.extend(encode_arity_bits(arity).expect("arity out of range"));
+            let arity_bits = encode_arity_bits(arity)
+                .ok_or_else(|| TelomereError::Config("arity out of range".into()))?;
+            bits.extend(arity_bits);
             bits.extend(encode_evql_bits(seed_index));
         }
         Header::Literal => bits.extend([true, false]),
         Header::LiteralLast => bits.extend([true, true, true, true, true, true]),
     }
-    pack_bits(&bits)
+    Ok(pack_bits(&bits))
 }
 
 /// Decode a Telomere header from a bitstream. Returns the header and number of
@@ -239,7 +242,7 @@ mod tests {
         ];
 
         for h in cases {
-            let enc = encode_header(&h);
+            let enc = encode_header(&h).unwrap();
             let (decoded, bits) = decode_header(&enc).unwrap();
             assert_eq!(decoded, h);
             assert!(bits <= enc.len() * 8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod compress;
 mod compress_stats;
 mod file_header;
 mod tlmr;
+mod error;
 // Gloss table support has been removed for the MVP.  The original
 // implementation used precomputed decompressed strings to accelerate
 // seed matching.  Future versions may reintroduce a `gloss` module.
@@ -49,6 +50,7 @@ pub use seed_logger::{
 pub use sha_cache::*;
 pub use stats::Stats;
 pub use tlmr::{decode_tlmr_header, encode_tlmr_header, truncated_hash, TlmrError, TlmrHeader};
+pub use error::TelomereError;
 
 pub fn print_compression_status(original: usize, compressed: usize) {
     let ratio = 100.0 * (1.0 - compressed as f64 / original as f64);
@@ -103,33 +105,33 @@ pub fn decompress_region_with_limit(
 /// Files begin with a 3-byte Telomere header describing protocol version,
 /// block size, last block size and a truncated output hash. Each subsequent
 /// region is prefixed with a normal header.
-pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, TlmrError> {
+pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, TelomereError> {
     if input.len() < 3 {
-        return Err(TlmrError::TooShort);
+        return Err(TelomereError::Decode("header too short".into()));
     }
-    let header = decode_tlmr_header(input)?;
+    let header = decode_tlmr_header(input).map_err(|e| TelomereError::Decode(format!("{e}")))?;
     let mut offset = 3usize;
     let block_size = header.block_size;
     let last_block_size = header.last_block_size;
     let mut out = Vec::new();
     loop {
-        let slice = input.get(offset..).ok_or(TlmrError::InvalidField)?;
-        let (header, bits) = decode_header(slice).map_err(|_| TlmrError::InvalidField)?;
+        let slice = input.get(offset..).ok_or_else(|| TelomereError::Decode("invalid header field".into()))?;
+        let (header, bits) = decode_header(slice).map_err(|_| TelomereError::Decode("invalid header field".into()))?;
         offset += (bits + 7) / 8;
         match header {
-            Header::Standard { seed_index, arity } | Header::Penultimate { seed_index, arity } => {
+            Header::Standard { seed_index, arity } => {
                 let needed = arity * block_size;
                 if out.len() + needed > limit {
-                    return Err(TlmrError::InvalidField);
+                    return Err(TelomereError::Decode("invalid header field".into()));
                 }
-                let seed = index_to_seed(seed_index, 2);
+                let seed = index_to_seed(seed_index, 2)?;
                 let generated = expand_seed(&seed, needed);
                 out.extend_from_slice(&generated);
             }
             Header::Literal => {
                 let bytes = block_size;
                 if out.len() + bytes > limit || offset + bytes > input.len() {
-                    return Err(TlmrError::InvalidField);
+                    return Err(TelomereError::Decode("invalid header field".into()));
                 }
                 out.extend_from_slice(&input[offset..offset + bytes]);
                 offset += bytes;
@@ -137,7 +139,7 @@ pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, Tlmr
             Header::LiteralLast => {
                 let bytes = last_block_size;
                 if out.len() + bytes > limit || offset + bytes > input.len() {
-                    return Err(TlmrError::InvalidField);
+                    return Err(TelomereError::Decode("invalid header field".into()));
                 }
                 out.extend_from_slice(&input[offset..offset + bytes]);
                 offset += bytes;
@@ -151,7 +153,7 @@ pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, Tlmr
     }
     let hash = truncated_hash(&out);
     if hash != header.output_hash {
-        return Err(TlmrError::OutputHashMismatch);
+        return Err(TelomereError::Decode("output hash mismatch".into()));
     }
     Ok(out)
 }

--- a/src/seed_index.rs
+++ b/src/seed_index.rs
@@ -30,12 +30,14 @@ pub fn seed_to_index(seed: &[u8], max_seed_len: usize) -> usize {
     index + value
 }
 
+use crate::TelomereError;
+
 /// Returns the canonical seed for the given enumeration index.
 ///
 /// The enumeration follows the July 2025 Telomere protocol. Indices are
 /// assigned in big-endian order, grouped first by seed length. Passing an
-/// index outside the valid range for `max_seed_len` will panic.
-pub fn index_to_seed(index: usize, max_seed_len: usize) -> Vec<u8> {
+/// index outside the valid range for `max_seed_len` returns an error.
+pub fn index_to_seed(index: usize, max_seed_len: usize) -> Result<Vec<u8>, TelomereError> {
     let mut remaining = index as u128;
     for len in 1..=max_seed_len {
         let count = 1u128 << (len * 8);
@@ -44,11 +46,11 @@ pub fn index_to_seed(index: usize, max_seed_len: usize) -> Vec<u8> {
             for i in 0..len {
                 seed[len - 1 - i] = ((remaining >> (8 * i)) & 0xFF) as u8;
             }
-            return seed;
+            return Ok(seed);
         }
         remaining -= count;
     }
-    panic!("index out of range");
+    Err(TelomereError::Decode("index out of range".into()))
 }
 
 #[cfg(test)]

--- a/tests/compress_literals.rs
+++ b/tests/compress_literals.rs
@@ -4,7 +4,7 @@ use telomere::{compress, decode_tlmr_header, decode_header, decompress_with_limi
 fn compress_writes_header_then_data() {
     let block_size = 3;
     let data: Vec<u8> = (0u8..50).collect();
-    let out = compress(&data, block_size);
+    let out = compress(&data, block_size).unwrap();
     let decompressed = decompress_with_limit(&out, usize::MAX).unwrap();
     assert_eq!(decompressed, data);
 
@@ -47,7 +47,7 @@ fn compress_writes_header_then_data() {
 fn compress_empty_input() {
     let block_size = 4usize;
     let data: Vec<u8> = Vec::new();
-    let out = compress(&data, block_size);
+    let out = compress(&data, block_size).unwrap();
     // output should only contain the tlmr header
     assert_eq!(out.len(), 3);
     let decompressed = telomere::decompress(&out);

--- a/tests/compress_roundtrip_random.rs
+++ b/tests/compress_roundtrip_random.rs
@@ -8,7 +8,7 @@ fn random_roundtrip() {
         let len = rng.gen_range(1..200);
         let block = rng.gen_range(2..8);
         let data: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
-        let out = compress(&data, block);
+        let out = compress(&data, block).unwrap();
         let decompressed = decompress_with_limit(&out, usize::MAX).unwrap();
         assert_eq!(data, decompressed);
     }
@@ -20,7 +20,7 @@ fn adversarial_roundtrip() {
     let pattern: [u8; 8] = [0x6e, 0x34, 0x0b, 0x9c, 0xff, 0xb3, 0x7a, 0x98];
     let mut data = pattern.to_vec();
     data.extend_from_slice(&[1,2,3,4]);
-    let out = compress(&data, 4);
+    let out = compress(&data, 4).unwrap();
     let decompressed = decompress_with_limit(&out, usize::MAX).unwrap();
     assert_eq!(data, decompressed);
 }

--- a/tests/dtoggle_header.rs
+++ b/tests/dtoggle_header.rs
@@ -72,7 +72,7 @@ fn arity_bit_patterns() {
         // Small seed index pattern
         let mut expected = bits.to_vec();
         expected.extend(evql_bits(small_seed));
-        let enc = encode_header(&Header::Standard { seed_index: small_seed, arity });
+        let enc = encode_header(&Header::Standard { seed_index: small_seed, arity }).unwrap();
         assert_eq!(enc, pack_bits(&expected), "arity {} small index", arity);
         let (decoded, _) = decode_header(&enc).unwrap();
         assert_eq!(decoded, Header::Standard { seed_index: small_seed, arity });
@@ -80,7 +80,7 @@ fn arity_bit_patterns() {
         // Large seed index pattern
         let mut expected_big = bits.to_vec();
         expected_big.extend(evql_bits(large_seed));
-        let enc_big = encode_header(&Header::Standard { seed_index: large_seed, arity });
+        let enc_big = encode_header(&Header::Standard { seed_index: large_seed, arity }).unwrap();
         assert_eq!(enc_big, pack_bits(&expected_big), "arity {} large index", arity);
         let (decoded_big, _) = decode_header(&enc_big).unwrap();
         assert_eq!(decoded_big, Header::Standard { seed_index: large_seed, arity });
@@ -92,8 +92,8 @@ fn literal_bit_patterns() {
     let lit = pack_bits(&[true, false]);
     let last = pack_bits(&[true, true, true, true, true, true]);
 
-    assert_eq!(encode_header(&Header::Literal), lit);
-    assert_eq!(encode_header(&Header::LiteralLast), last);
+    assert_eq!(encode_header(&Header::Literal).unwrap(), lit);
+    assert_eq!(encode_header(&Header::LiteralLast).unwrap(), last);
 
     let (dec_lit, _) = decode_header(&lit).unwrap();
     assert_eq!(dec_lit, Header::Literal);
@@ -126,7 +126,7 @@ fn seed_index_lengths() {
         let arity_bits = [false]; // arity 1 -> single zero bit
         let mut all = arity_bits.to_vec();
         all.extend(bits.clone());
-        let enc = encode_header(&Header::Standard { seed_index: seed, arity: 1 });
+        let enc = encode_header(&Header::Standard { seed_index: seed, arity: 1 }).unwrap();
         assert_eq!(enc, pack_bits(&all));
         let (dec, used) = decode_header(&enc).unwrap();
         assert_eq!(dec, Header::Standard { seed_index: seed, arity: 1 });
@@ -137,10 +137,10 @@ fn seed_index_lengths() {
 #[test]
 fn truncated_headers_fail() {
     // Truncate a valid header so not all bits are available
-    let full = encode_header(&Header::Standard { seed_index: 1, arity: 3 });
+    let full = encode_header(&Header::Standard { seed_index: 1, arity: 3 }).unwrap();
     assert!(decode_header(&full[..0]).is_err());
 
     // Truncated literal marker
-    let lit = encode_header(&Header::Literal);
+    let lit = encode_header(&Header::Literal).unwrap();
     assert!(decode_header(&lit[..0]).is_err());
 }

--- a/tests/header_prop.rs
+++ b/tests/header_prop.rs
@@ -4,27 +4,21 @@ use telomere::{encode_header, decode_header, Header};
 quickcheck! {
     fn header_roundtrip(seed: usize, arity: u8, variant: u8) -> bool {
         let seed = seed % 1_000_000; // keep indices small
-        match variant % 4 {
+        match variant % 3 {
             0 => {
                 let a = (arity % 7) + 1;
                 let h = Header::Standard { seed_index: seed, arity: a as usize };
-                let enc = encode_header(&h);
+                let enc = encode_header(&h).unwrap();
                 match decode_header(&enc) { Ok((d, _)) => d == h, Err(_) => false }
             }
             1 => {
-                let a = (arity % 3) + 1;
-                let h = Header::Penultimate { seed_index: seed, arity: a as usize };
-                let enc = encode_header(&h);
-                match decode_header(&enc) { Ok((d, _)) => d == h, Err(_) => false }
-            }
-            2 => {
                 let h = Header::Literal;
-                let enc = encode_header(&h);
+                let enc = encode_header(&h).unwrap();
                 match decode_header(&enc) { Ok((d, _)) => d == h, Err(_) => false }
             }
             _ => {
                 let h = Header::LiteralLast;
-                let enc = encode_header(&h);
+                let enc = encode_header(&h).unwrap();
                 match decode_header(&enc) { Ok((d, _)) => d == h, Err(_) => false }
             }
         }

--- a/tests/header_tests.rs
+++ b/tests/header_tests.rs
@@ -11,7 +11,7 @@ fn header_roundtrip_across_ranges() {
         Header::LiteralLast,
     ];
     for h in cases {
-        let enc = encode_header(&h);
+        let enc = encode_header(&h).unwrap();
         let (decoded, _) = decode_header(&enc).expect("decode failed");
         assert_eq!(h, decoded);
     }

--- a/tests/index_to_seed.rs
+++ b/tests/index_to_seed.rs
@@ -2,11 +2,11 @@ use telomere::index_to_seed;
 
 #[test]
 fn basic_indices() {
-    assert_eq!(index_to_seed(0, 4), vec![0x00]);
-    assert_eq!(index_to_seed(1, 4), vec![0x01]);
-    assert_eq!(index_to_seed(255, 4), vec![0xFF]);
-    assert_eq!(index_to_seed(256, 4), vec![0x00, 0x00]);
-    assert_eq!(index_to_seed(257, 4), vec![0x00, 0x01]);
-    assert_eq!(index_to_seed(65791, 4), vec![0xFF, 0xFF]);
-    assert_eq!(index_to_seed(65792, 4), vec![0x00, 0x00, 0x00]);
+    assert_eq!(index_to_seed(0, 4).unwrap(), vec![0x00]);
+    assert_eq!(index_to_seed(1, 4).unwrap(), vec![0x01]);
+    assert_eq!(index_to_seed(255, 4).unwrap(), vec![0xFF]);
+    assert_eq!(index_to_seed(256, 4).unwrap(), vec![0x00, 0x00]);
+    assert_eq!(index_to_seed(257, 4).unwrap(), vec![0x00, 0x01]);
+    assert_eq!(index_to_seed(65791, 4).unwrap(), vec![0xFF, 0xFF]);
+    assert_eq!(index_to_seed(65792, 4).unwrap(), vec![0x00, 0x00, 0x00]);
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -4,7 +4,7 @@ use telomere::{compress, decompress};
 quickcheck! {
     fn random_roundtrip(data: Vec<u8>, bs: u8) -> bool {
         let block_size = (bs % 16 + 1) as usize; // limit block size 1..16
-        let out = compress(&data, block_size);
+        let out = compress(&data, block_size).unwrap();
         let decoded = decompress(&out);
         decoded == data
     }
@@ -14,7 +14,7 @@ quickcheck! {
 fn fixed_roundtrip() {
     let block_size = 3usize;
     let input: Vec<u8> = (0u8..100).collect();
-    let out = compress(&input, block_size);
+    let out = compress(&input, block_size).unwrap();
     let decoded = decompress(&out);
     assert_eq!(input, decoded);
 }

--- a/tests/seed_index.rs
+++ b/tests/seed_index.rs
@@ -8,7 +8,7 @@ quickcheck! {
         // Calculate the total number of valid indices for MAX_LEN
         let total: u128 = (1u128 << 8) + (1u128 << 16) + (1u128 << 24);
         let idx = (idx as u128 % total) as usize;
-        let seed = index_to_seed(idx, MAX_LEN);
+        let seed = index_to_seed(idx, MAX_LEN).unwrap();
         seed_to_index(&seed, MAX_LEN) == idx
     }
 }
@@ -19,7 +19,7 @@ quickcheck! {
             return true; // vacuously true for out-of-bounds seeds
         }
         let idx = seed_to_index(&seed, MAX_LEN);
-        index_to_seed(idx, MAX_LEN) == seed
+        index_to_seed(idx, MAX_LEN).unwrap() == seed
     }
 }
 
@@ -35,9 +35,9 @@ fn edge_cases() {
         256 + 65536usize + 16777216usize - 1, // last 3-byte
     ];
     for &idx in &edges {
-        let seed = index_to_seed(idx, MAX_LEN);
+        let seed = index_to_seed(idx, MAX_LEN).unwrap();
         assert_eq!(seed_to_index(&seed, MAX_LEN), idx);
-        assert_eq!(index_to_seed(seed_to_index(&seed, MAX_LEN), MAX_LEN), seed);
+        assert_eq!(index_to_seed(seed_to_index(&seed, MAX_LEN), MAX_LEN).unwrap(), seed);
     }
 }
 
@@ -48,8 +48,7 @@ fn empty_seed_panics() {
 }
 
 #[test]
-#[should_panic]
-fn index_overflow_panics() {
+fn index_overflow_errors() {
     let total = (1usize << 8) + (1usize << 16) + (1usize << 24);
-    let _ = index_to_seed(total, MAX_LEN);
+    assert!(index_to_seed(total, MAX_LEN).is_err());
 }

--- a/tests/tlmr_header.rs
+++ b/tests/tlmr_header.rs
@@ -37,12 +37,12 @@ fn build_data(bytes: &[u8], bs: usize) -> Vec<u8> {
     let mut out = hdr.to_vec();
     let mut offset = 0usize;
     while offset + bs <= bytes.len() {
-        out.extend_from_slice(&encode_header(&Header::Literal));
+        out.extend_from_slice(&encode_header(&Header::Literal).unwrap());
         out.extend_from_slice(&bytes[offset..offset + bs]);
         offset += bs;
     }
     if offset < bytes.len() {
-        out.extend_from_slice(&encode_header(&Header::LiteralLast));
+        out.extend_from_slice(&encode_header(&Header::LiteralLast).unwrap());
         out.extend_from_slice(&bytes[offset..]);
     }
     out
@@ -72,7 +72,7 @@ fn wrong_hash_fails() {
 fn random_roundtrip() {
     let bs = 5;
     let data: Vec<u8> = (0u8..37).collect();
-    let out = compress(&data, bs);
+    let out = compress(&data, bs).unwrap();
     let decoded = decompress_with_limit(&out, usize::MAX).unwrap();
     assert_eq!(data, decoded);
 }


### PR DESCRIPTION
## Summary
- implement `TelomereError` in new `src/error.rs`
- expose error type from library and update header and seed APIs
- propagate errors through compression/decompression code
- adapt CLI utilities to new Result signatures
- update tests for new APIs and add check for decode error

## Testing
- `cargo test --no-run`
- `cargo test compress_roundtrip_random::adversarial_roundtrip -- --nocapture` *(fails: test `adversarial_roundtrip` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879d81d8d408329926149c4b793db8b