### PR TITLE
Fix module declarations and expose header API

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1,25 +1,3 @@
-//! Batch header encoding using EVQL bit packing as defined in the project specification.
-//!
-//! A header begins with a small fixed layout describing the batch
-//! metadata followed by a sequence of span descriptors. Each span
-//! stores an arity and seed index. All fields are packed bitwise using
-//! a simple `BitWriter` so no alignment padding is inserted.
-//!
-//! Layout (from most significant bit to least):
-//!
-//! ```text
-//! version:2 | block_size:4 | hash_len:10 | EVQL(block_count)
-//! [ per span: arity bits | EVQL(seed_index) ]*
-//! ```
-//!
-//! Arity encoding uses the July 2025 scheme:
-//! - `0`                => arity 1
-//! - `10`               => arity 2 / literal marker
-//! - `EVQL(n)` (n>=3)   => arity n
-//!
-//! All helper routines return the number of bits consumed so callers can
-//! advance the byte stream if additional data follows.
-
 use crate::TelomereError;
 use std::collections::HashMap;
 
@@ -30,13 +8,15 @@ pub struct Span {
     pub seed_index: usize,
 }
 
-/// Header metadata and associated spans.
+/// Single header encoding for compressed spans.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Header {
-    pub version: u8,
-    pub block_size: u8,
-    pub hash_len: u16,
-    pub spans: Vec<Span>,
+pub enum Header {
+    /// Seeded span with a given arity.
+    Standard { seed_index: usize, arity: usize },
+    /// Literal passthrough for one block.
+    Literal,
+    /// Literal passthrough for the final tail.
+    LiteralLast,
 }
 
 /// Configuration for recursive decoding.
@@ -47,128 +27,31 @@ pub struct Config {
     pub seed_expansions: HashMap<usize, Vec<u8>>,
 }
 
-// --------------------------------------------------------------------------
-// Batch header encode/decode
-
-/// Encode a batch header as described in §3 of the July 2025 Telomere
-/// specification.
-///
-/// The bitstream layout is:
-/// `version:2 | block_size:4 | hash_len:10 | EVQL(span_count)` followed by
-/// one or more span descriptors.  Each span descriptor encodes the arity using
-/// the `0`/`10`/`EVQL` scheme and then the `seed_index` as an EVQL value.
-///
-/// Returns a `Vec<u8>` containing the packed big‑endian bits.
-pub fn encode_header(header: &Header) -> Vec<u8> {
-    let mut bw = BitWriter::new();
-    bw.write_bits(header.version as u64, 2);
-    bw.write_bits(header.block_size as u64, 4);
-    bw.write_bits(header.hash_len as u64, 10);
-    write_evql(&mut bw, header.spans.len());
-    for span in &header.spans {
-        match span.arity {
-            1 => bw.write_bit(false),
-            2 => {
-                bw.write_bit(true);
-                bw.write_bit(false);
-            }
-            n => write_evql(&mut bw, n),
-        }
-        write_evql(&mut bw, span.seed_index);
-    }
-    bw.finish()
-}
-
-/// Decode a batch header previously written by [`encode_header`].
-///
-/// Returns the reconstructed [`Header`] along with the number of bits
-/// consumed from the input.  `TelomereError::UnexpectedEof` is
-/// returned if the input ends prematurely.
-pub fn decode_header(data: &[u8]) -> Result<(Header, usize), TelomereError> {
-    let mut br = BitReader::new(data);
-    let version = br.read_bits(2)? as u8;
-    let block_size = br.read_bits(4)? as u8;
-    let hash_len = br.read_bits(10)? as u16;
-    let span_count = read_evql(&mut br)?;
-    let mut spans = Vec::with_capacity(span_count);
-    for _ in 0..span_count {
-        let first = br.read_bit()?;
-        let arity = if !first {
-            1
-        } else if !br.read_bit()? {
-            2
-        } else {
-            read_evql(&mut br)?
-        };
-        let seed = read_evql(&mut br)?;
-        spans.push(Span { arity, seed_index: seed });
-    }
-    let used = br.bits_read();
-    Ok((Header { version, block_size, hash_len, spans }, used))
-}
-
-// --------------------------------------------------------------------------
-// bitstream helpers
-
-struct BitWriter {
-    out: Vec<u8>,
-    cur: u8,
-    used: u8,
-}
-
-impl BitWriter {
-    fn new() -> Self {
-        Self { out: Vec::new(), cur: 0, used: 0 }
-    }
-
-    fn write_bit(&mut self, bit: bool) {
-        self.cur = (self.cur << 1) | bit as u8;
-        self.used += 1;
-        if self.used == 8 {
-            self.out.push(self.cur);
-            self.cur = 0;
-            self.used = 0;
-        }
-    }
-
-    fn write_bits(&mut self, val: u64, bits: usize) {
-        for i in (0..bits).rev() {
-            self.write_bit(((val >> i) & 1) != 0);
-        }
-    }
-
-    fn finish(mut self) -> Vec<u8> {
-        if self.used > 0 {
-            self.cur <<= 8 - self.used;
-            self.out.push(self.cur);
-        }
-        if self.out.is_empty() {
-            self.out.push(0);
-        }
-        self.out
-    }
-}
-
-struct BitReader<'a> {
+/// Bit level reader used by the decoder tests.
+#[derive(Debug, Clone)]
+pub struct BitReader<'a> {
     data: &'a [u8],
     pos: usize,
 }
 
 impl<'a> BitReader<'a> {
-    fn new(data: &'a [u8]) -> Self {
+    /// Create a reader from a byte slice.
+    pub fn from_slice(data: &'a [u8]) -> Self {
         Self { data, pos: 0 }
     }
 
-    fn read_bit(&mut self) -> Result<bool, TelomereError> {
+    /// Read a single bit returning an error on EOF.
+    pub fn read_bit(&mut self) -> Result<bool, TelomereError> {
         if self.pos / 8 >= self.data.len() {
-            return Err(TelomereError::UnexpectedEof);
+            return Err(TelomereError::Decode("unexpected EOF".into()));
         }
         let bit = ((self.data[self.pos / 8] >> (7 - (self.pos % 8))) & 1) != 0;
         self.pos += 1;
         Ok(bit)
     }
 
-    fn read_bits(&mut self, bits: usize) -> Result<u64, TelomereError> {
+    /// Read an arbitrary number of bits.
+    pub fn read_bits(&mut self, bits: usize) -> Result<u64, TelomereError> {
         let mut v = 0u64;
         for _ in 0..bits {
             v = (v << 1) | self.read_bit()? as u64;
@@ -176,104 +59,157 @@ impl<'a> BitReader<'a> {
         Ok(v)
     }
 
-    fn bits_read(&self) -> usize {
-        self.pos
-    }
-}
-
-fn write_evql(w: &mut BitWriter, mut value: usize) {
-    let mut width = 1usize;
-    let mut n = 0usize;
-    while value >= (1usize << width) {
-        width <<= 1;
-        n += 1;
-    }
-    for _ in 0..n {
-        w.write_bit(true);
-    }
-    w.write_bit(false);
-    for i in (0..width).rev() {
-        w.write_bit(((value >> i) & 1) != 0);
-    }
-}
-
-fn read_evql(r: &mut BitReader) -> Result<usize, TelomereError> {
-    let mut n = 0usize;
-    loop {
-        match r.read_bit()? {
-            true => n += 1,
-            false => break,
-        }
-    }
-    let width = 1usize << n;
-    let mut value = 0usize;
-    for _ in 0..width {
-        value = (value << 1) | r.read_bit()? as usize;
-    }
-    Ok(value)
-}
-
-// --------------------------------------------------------------------------
-// Recursive decoding
-
-fn generate_bits(config: &Config, seed_idx: usize) -> Result<Vec<u8>, TelomereError> {
-    config
-        .seed_expansions
-        .get(&seed_idx)
-        .cloned()
-        .ok_or_else(|| TelomereError::Other(format!("missing seed expansion for {}", seed_idx)))
-}
-
-/// A utility for recursive bit-level reading from a byte slice.
-struct BitReaderDyn<'a> {
-    data: &'a [u8],
-    pos: usize,
-}
-impl<'a> BitReaderDyn<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self { data, pos: 0 }
-    }
-    fn read_bit(&mut self) -> Result<bool, TelomereError> {
-        if self.pos / 8 >= self.data.len() {
-            return Err(TelomereError::UnexpectedEof);
-        }
-        let bit = ((self.data[self.pos / 8] >> (7 - (self.pos % 8))) & 1) != 0;
-        self.pos += 1;
-        Ok(bit)
-    }
-    fn read_bits(&mut self, bits: usize) -> Result<u64, TelomereError> {
-        let mut v = 0u64;
-        for _ in 0..bits {
-            v = (v << 1) | self.read_bit()? as u64;
-        }
-        Ok(v)
-    }
-    fn read_bytes(&mut self, count: usize) -> Result<Vec<u8>, TelomereError> {
+    /// Read a byte slice from the underlying bits.
+    pub fn read_bytes(&mut self, count: usize) -> Result<Vec<u8>, TelomereError> {
         let mut out = Vec::with_capacity(count);
         for _ in 0..count {
             out.push(self.read_bits(8)? as u8);
         }
         Ok(out)
     }
+
+    /// Number of bits consumed so far.
+    pub fn bits_read(&self) -> usize {
+        self.pos
+    }
 }
 
-fn decode_span<'a>(reader: &mut BitReaderDyn<'a>, config: &Config) -> Result<Vec<u8>, TelomereError> {
+fn pack_bits(bits: &[bool]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut byte = 0u8;
+    let mut used = 0u8;
+    for &b in bits {
+        byte = (byte << 1) | b as u8;
+        used += 1;
+        if used == 8 {
+            out.push(byte);
+            byte = 0;
+            used = 0;
+        }
+    }
+    if used > 0 {
+        byte <<= 8 - used;
+        out.push(byte);
+    }
+    if out.is_empty() { out.push(0); }
+    out
+}
+
+fn encode_evql_bits(mut value: usize) -> Vec<bool> {
+    let mut width = 1usize;
+    let mut n = 0usize;
+    while value >= (1usize << width) {
+        width <<= 1;
+        n += 1;
+    }
+    let mut bits = vec![true; n];
+    bits.push(false);
+    for i in (0..width).rev() {
+        bits.push(((value >> i) & 1) != 0);
+    }
+    bits
+}
+
+fn decode_evql(reader: &mut BitReader) -> Result<usize, TelomereError> {
+    let mut n = 0usize;
+    loop {
+        if reader.read_bit()? { n += 1; } else { break; }
+    }
+    let width = 1usize << n;
+    let mut val = 0usize;
+    for _ in 0..width {
+        val = (val << 1) | reader.read_bit()? as usize;
+    }
+    Ok(val)
+}
+
+/// Encode a span header using the July 2025 bit layout.
+pub fn encode_header(header: &Header) -> Result<Vec<u8>, TelomereError> {
+    let mut bits = Vec::new();
+    match header {
+        Header::Standard { seed_index, arity } => {
+            match *arity {
+                1 => bits.push(false),
+                3..=9 => {
+                    bits.extend_from_slice(&[true, true]);
+                    let val = arity - 3;
+                    for i in (0..3).rev() {
+                        bits.push(((val >> i) & 1) != 0);
+                    }
+                }
+                10 => bits.extend_from_slice(&[true, true, true, true, true, false]),
+                _ => return Err(TelomereError::Other(format!("unsupported arity {arity}"))),
+            }
+            bits.extend(encode_evql_bits(*seed_index));
+        }
+        Header::Literal => bits.extend_from_slice(&[true, false]),
+        Header::LiteralLast => bits.extend_from_slice(&[true, true, true, true, true, true]),
+    }
+    Ok(pack_bits(&bits))
+}
+
+/// Decode a span header returning the header and bits consumed.
+pub fn decode_header(data: &[u8]) -> Result<(Header, usize), TelomereError> {
+    let mut r = BitReader::from_slice(data);
+    let first = r.read_bit()?;
+    if !first {
+        let seed = decode_evql(&mut r)?;
+        return Ok((Header::Standard { seed_index: seed, arity: 1 }, r.bits_read()));
+    }
+    let second = r.read_bit()?;
+    if !second {
+        return Ok((Header::Literal, r.bits_read()));
+    }
+    let b1 = r.read_bit()?;
+    let b2 = r.read_bit()?;
+    let b3 = r.read_bit()?;
+    let val = (b1 as usize) << 2 | (b2 as usize) << 1 | (b3 as usize);
+    if val <= 6 {
+        let arity = val + 3;
+        let seed = decode_evql(&mut r)?;
+        return Ok((Header::Standard { seed_index: seed, arity }, r.bits_read()));
+    }
+    let b4 = r.read_bit()?;
+    if !b4 {
+        let seed = decode_evql(&mut r)?;
+        return Ok((Header::Standard { seed_index: seed, arity: 10 }, r.bits_read()));
+    }
+    Ok((Header::LiteralLast, r.bits_read()))
+}
+
+fn generate_bits(config: &Config, seed_idx: usize) -> Result<Vec<u8>, TelomereError> {
+    config
+        .seed_expansions
+        .get(&seed_idx)
+        .cloned()
+        .ok_or_else(|| TelomereError::Other(format!("missing seed expansion for {seed_idx}")))
+}
+
+fn decode_span(reader: &mut BitReader, config: &Config) -> Result<Vec<u8>, TelomereError> {
     let first = reader.read_bit()?;
     let arity = if !first {
         1
     } else if !reader.read_bit()? {
         2
     } else {
-        read_evql(reader)?
+        let b1 = reader.read_bit()?;
+        let b2 = reader.read_bit()?;
+        let b3 = reader.read_bit()?;
+        let val = (b1 as usize) << 2 | (b2 as usize) << 1 | (b3 as usize);
+        if val <= 6 {
+            val + 3
+        } else if !reader.read_bit()? {
+            10
+        } else {
+            return Err(TelomereError::Other("literal last not allowed".into()));
+        }
     };
     if arity == 2 {
-        // literal: read raw block_size bytes
         return reader.read_bytes(config.block_size);
     }
-    // seeded: read seed_index, get expansion, decode children recursively
-    let seed_idx = read_evql(reader)?;
+    let seed_idx = decode_evql(reader)?;
     let child_bits = generate_bits(config, seed_idx)?;
-    let mut child_reader = BitReaderDyn::new(&child_bits);
+    let mut child_reader = BitReader::from_slice(&child_bits);
     let mut out = Vec::new();
     for _ in 0..arity {
         out.extend(decode_span(&mut child_reader, config)?);
@@ -282,8 +218,8 @@ fn decode_span<'a>(reader: &mut BitReaderDyn<'a>, config: &Config) -> Result<Vec
 }
 
 /// Decode a stream of blocks described by nested headers.
-pub fn decode_recursive<'a>(reader: &mut BitReaderDyn<'a>, config: &Config) -> Result<Vec<u8>, TelomereError> {
-    let block_count = read_evql(reader)?;
+pub fn decode(reader: &mut BitReader, config: &Config) -> Result<Vec<u8>, TelomereError> {
+    let block_count = decode_evql(reader)?;
     let mut result = Vec::new();
     for _ in 0..block_count {
         result.extend(decode_span(reader, config)?);
@@ -291,53 +227,23 @@ pub fn decode_recursive<'a>(reader: &mut BitReaderDyn<'a>, config: &Config) -> R
     Ok(result)
 }
 
-// --------------------------------------------------------------------------
-// Tests
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn roundtrip_known_stream() -> Result<(), TelomereError> {
-        let header = Header {
-            version: 1,
-            block_size: 4,
-            hash_len: 12,
-            spans: vec![
-                Span { arity: 1, seed_index: 3 },
-                Span { arity: 2, seed_index: 1 },
-                Span { arity: 5, seed_index: 2 },
-            ],
-        };
-        let enc = encode_header(&header);
-        let (dec, used) = decode_header(&enc)?;
-        assert_eq!(dec, header);
-        assert!(used <= enc.len() * 8);
-        Ok(())
-    }
-
-    #[test]
-    fn literal_marker_bits() {
-        let header = Header {
-            version: 0,
-            block_size: 2,
-            hash_len: 10,
-            spans: vec![Span { arity: 2, seed_index: 0 }],
-        };
-        let enc = encode_header(&header);
-        // expected prefix length: 2 + 4 + 10 + EVQL(1) = 18 bits
-        let bits: Vec<char> = enc
-            .iter()
-            .flat_map(|b| (0..8).rev().map(move |i| if (b >> i) & 1 == 1 { '1' } else { '0' }))
-            .collect();
-        let prefix = 18usize;
-        assert_eq!(&bits[prefix..prefix + 2], ['1', '0']);
-    }
-
-    #[test]
-    fn recursive_decode_example() -> Result<(), TelomereError> {
-        // TODO: Add a real multi-level header + seed_expansions test case.
-        Ok(())
+    fn roundtrip_header() {
+        let cases = [
+            Header::Standard { seed_index: 0, arity: 1 },
+            Header::Standard { seed_index: 3, arity: 3 },
+            Header::Literal,
+            Header::LiteralLast,
+        ];
+        for h in cases {
+            let enc = encode_header(&h).unwrap();
+            let (dec, _) = decode_header(&enc).unwrap();
+            assert_eq!(dec, h);
+        }
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,8 @@ pub use header::{
     encode_header,
     BitReader,
     Config,
+    Span,
     Header,
-    HeaderError,
-    TelomereError,
 };
 pub use io_utils::*;
 pub use live_window::{print_window, LiveStats};
@@ -124,6 +123,9 @@ pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, Telo
     let last_block_size = header.last_block_size;
     let mut out = Vec::new();
     loop {
+        if offset == input.len() {
+            break;
+        }
         let slice = input.get(offset..).ok_or_else(|| TelomereError::Decode("invalid header field".into()))?;
         let (header, bits) = decode_header(slice).map_err(|_| TelomereError::Decode("invalid header field".into()))?;
         offset += (bits + 7) / 8;
@@ -168,6 +170,6 @@ pub fn decompress_with_limit(input: &[u8], limit: usize) -> Result<Vec<u8>, Telo
 }
 
 /// Convenience wrapper without a limit.
-pub fn decompress(input: &[u8]) -> Vec<u8> {
-    decompress_with_limit(input, usize::MAX).unwrap_or_default()
+pub fn decompress(input: &[u8]) -> Result<Vec<u8>, TelomereError> {
+    decompress_with_limit(input, usize::MAX)
 }

--- a/tests/compress_literals.rs
+++ b/tests/compress_literals.rs
@@ -50,6 +50,6 @@ fn compress_empty_input() {
     let out = compress(&data, block_size).unwrap();
     // output should only contain the tlmr header
     assert_eq!(out.len(), 3);
-    let decompressed = telomere::decompress(&out);
+    let decompressed = telomere::decompress(&out).unwrap();
     assert!(decompressed.is_empty());
 }

--- a/tests/decompress.rs
+++ b/tests/decompress.rs
@@ -144,6 +144,6 @@ fn empty_roundtrip() {
     let block_size = 4usize;
     let data: Vec<u8> = Vec::new();
     let buf = compress(&data, block_size).unwrap();
-    let out = telomere::decompress(&buf);
+    let out = telomere::decompress(&buf).unwrap();
     assert!(out.is_empty());
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -5,7 +5,7 @@ quickcheck! {
     fn random_roundtrip(data: Vec<u8>, bs: u8) -> bool {
         let block_size = (bs % 16 + 1) as usize; // limit block size 1..16
         let out = compress(&data, block_size).unwrap();
-        let decoded = decompress(&out);
+        let decoded = decompress(&out).unwrap();
         decoded == data
     }
 }
@@ -15,6 +15,6 @@ fn fixed_roundtrip() {
     let block_size = 3usize;
     let input: Vec<u8> = (0u8..100).collect();
     let out = compress(&input, block_size).unwrap();
-    let decoded = decompress(&out);
+    let decoded = decompress(&out).unwrap();
     assert_eq!(input, decoded);
 }


### PR DESCRIPTION
## Summary
- add full header module with span encode/decode support
- export new header types from the library
- return `Result` from `decompress`
- update tests for new API
- handle empty stream in `decompress_with_limit`

## Testing
- `cargo test -- --test-threads=1` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_687aa8f1f19c8329ae66f6655d4e3493