### PR TITLE
Implement brute-force seed indexing

### DIFF
--- a/src/block_indexer.rs
+++ b/src/block_indexer.rs
@@ -1,0 +1,68 @@
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+
+use crate::{index_to_seed, TelomereError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeedMatch {
+    pub block_index: usize,
+    pub seed_index: usize,
+    pub block_len: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexedBlock {
+    pub index: usize,
+    pub len: usize,
+    pub matches: Vec<usize>,
+}
+
+fn expand_seed(seed: &[u8], len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut cur = seed.to_vec();
+    while out.len() < len {
+        let digest: [u8; 32] = Sha256::digest(&cur).into();
+        out.extend_from_slice(&digest);
+        cur = digest.to_vec();
+    }
+    out.truncate(len);
+    out
+}
+
+pub fn brute_force_seed_tables(
+    data: &[u8],
+    max_block_size: usize,
+    max_seed_len: usize,
+) -> Result<HashMap<usize, Vec<IndexedBlock>>, TelomereError> {
+    let mut tables: HashMap<usize, Vec<IndexedBlock>> = HashMap::new();
+    let mut limit: u128 = 0;
+    for len in 1..=max_seed_len {
+        limit += 1u128 << (8 * len);
+    }
+    for block_size in 1..=max_block_size {
+        let mut blocks = Vec::new();
+        let mut offset = 0usize;
+        let mut idx = 0usize;
+        while offset < data.len() {
+            let end = (offset + block_size).min(data.len());
+            let slice = &data[offset..end];
+            let mut matches = Vec::new();
+            for s_idx in 0..limit {
+                let seed = index_to_seed(s_idx as usize, max_seed_len)?;
+                if expand_seed(&seed, slice.len()) == slice {
+                    matches.push(s_idx as usize);
+                }
+            }
+            blocks.push(IndexedBlock {
+                index: idx,
+                len: slice.len(),
+                matches,
+            });
+            offset += block_size;
+            idx += 1;
+        }
+        tables.insert(block_size, blocks);
+    }
+    Ok(tables)
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod seed_detect;
 mod seed_index;
 mod seed_logger;
 mod sha_cache;
+mod block_indexer;
 mod stats;
 use sha2::{Digest, Sha256};
 
@@ -56,6 +57,7 @@ pub use seed_logger::{
     log_seed, log_seed_to, resume_seed_index, resume_seed_index_from, HashEntry, ResourceLimits,
 };
 pub use sha_cache::*;
+pub use block_indexer::{brute_force_seed_tables, IndexedBlock, SeedMatch};
 pub use stats::Stats;
 pub use tlmr::{decode_tlmr_header, encode_tlmr_header, truncated_hash, TlmrError, TlmrHeader};
 pub use error::TelomereError;

--- a/tests/brute_force_index.rs
+++ b/tests/brute_force_index.rs
@@ -1,0 +1,30 @@
+use telomere::brute_force_seed_tables;
+
+#[test]
+fn seed_zero_matches_across_block_sizes() {
+    // SHA-256 of seed 0 starts with 6e 34 0b
+    let data = [0x6e, 0x34, 0x0b];
+    let tables = brute_force_seed_tables(&data, 3, 1).expect("indexing");
+    // block size 1: three blocks
+    let bs1 = tables.get(&1).unwrap();
+    assert_eq!(bs1.len(), 3);
+    assert!(bs1[0].matches.contains(&0));
+    // block size 2: two blocks (last is partial)
+    let bs2 = tables.get(&2).unwrap();
+    assert_eq!(bs2.len(), 2);
+    assert!(bs2[0].matches.contains(&0));
+    // block size 3: one block
+    let bs3 = tables.get(&3).unwrap();
+    assert_eq!(bs3.len(), 1);
+    assert!(bs3[0].matches.contains(&0));
+}
+
+#[test]
+fn final_partial_block_included() {
+    let data = [1u8, 2, 3, 4];
+    let tables = brute_force_seed_tables(&data, 3, 1).expect("indexing");
+    // for block size 3 there should be two entries, second is partial len 1
+    let bs3 = tables.get(&3).unwrap();
+    assert_eq!(bs3.len(), 2);
+    assert_eq!(bs3[1].len, 1);
+}


### PR DESCRIPTION
## Summary
- add `block_indexer` module
- expose brute-force seed table builder
- test seed table generation on simple inputs

## Testing
- `cargo test --test brute_force_index -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_687ae2b8a15c8329a53c2827dc21822c