### PR TITLE
Add property and roundtrip tests for core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@ src/bin/seed_table.rs
 !tests/nested_decode.rs
 !tests/header_patterns.rs
 !tests/hybrid_match.rs
+!tests/block_tests.rs
+!tests/header_roundtrip.rs
+!tests/compress_determinism.rs
+!tests/seed_index_mapping.rs
+!tests/decompress_validation.rs
 seed_table.csv
 run_table.bat
 table_24.csv

--- a/tests/block_tests.rs
+++ b/tests/block_tests.rs
@@ -1,0 +1,65 @@
+use telomere::{split_into_blocks, group_by_bit_length, collapse_branches, Block, BranchStatus};
+
+#[test]
+fn test_block_splitting_correctness() {
+    // Splitting should produce three full blocks of 3 bytes and one final 1 byte block
+    let input: Vec<u8> = (0u8..10).collect();
+    let blocks = split_into_blocks(&input, 24); // 24 bits = 3 bytes per block
+    assert_eq!(blocks.len(), 4);
+    assert_eq!(blocks[0].data, vec![0, 1, 2]);
+    assert_eq!(blocks[3].data, vec![9]);
+}
+
+#[test]
+fn test_block_bit_length_grouping() {
+    // Different bytes but identical length should group under the same bit length key
+    let input_a = vec![1u8, 2, 3];
+    let input_b = vec![0xFFu8; 3];
+    let mut blocks = split_into_blocks(&input_a, 24);
+    blocks.extend(split_into_blocks(&input_b, 24));
+    let table = group_by_bit_length(blocks);
+    assert!(table.get(&24).map_or(false, |g| g.len() >= 2));
+}
+
+#[test]
+fn test_collapse_branches_keeps_shortest() {
+    // When collapsing from index 0 only the shortest branch for that index should remain
+    let blocks = vec![
+        Block {
+            global_index: 0,
+            bit_length: 16,
+            data: vec![0, 1],
+            digest: [0u8; 32],
+            arity: None,
+            seed_index: None,
+            branch_label: 'A',
+            status: BranchStatus::Active,
+        },
+        Block {
+            global_index: 0,
+            bit_length: 8,
+            data: vec![2],
+            digest: [0u8; 32],
+            arity: None,
+            seed_index: None,
+            branch_label: 'B',
+            status: BranchStatus::Active,
+        },
+        Block {
+            global_index: 1,
+            bit_length: 8,
+            data: vec![3],
+            digest: [0u8; 32],
+            arity: None,
+            seed_index: None,
+            branch_label: 'A',
+            status: BranchStatus::Active,
+        },
+    ];
+    let mut table = group_by_bit_length(blocks);
+    collapse_branches(&mut table, 0);
+    // index 0 should retain only one branch with 8 bits
+    let branches = table.branches_for(0);
+    assert_eq!(branches.len(), 1);
+    assert_eq!(branches[0].bit_length, 8);
+}

--- a/tests/compress_determinism.rs
+++ b/tests/compress_determinism.rs
@@ -1,0 +1,19 @@
+use telomere::{compress, decompress_with_limit};
+
+#[test]
+fn test_compression_roundtrip_stability() {
+    // Compressing and then decompressing should yield the original bytes
+    let input: Vec<u8> = (0u8..50).collect();
+    let compressed = compress(&input, 3).unwrap();
+    let decompressed = decompress_with_limit(&compressed, usize::MAX).unwrap();
+    assert_eq!(decompressed, input);
+}
+
+#[test]
+fn test_compression_does_not_modify_input() {
+    // The compress function should not mutate the provided input slice
+    let original: Vec<u8> = (0u8..30).collect();
+    let input_copy = original.clone();
+    let _ = compress(&input_copy, 4).unwrap();
+    assert_eq!(original, input_copy);
+}

--- a/tests/decompress_validation.rs
+++ b/tests/decompress_validation.rs
@@ -1,0 +1,19 @@
+use telomere::{compress, decompress_with_limit};
+
+#[test]
+fn test_invalid_truncated_file_fails() {
+    // Truncating a valid compressed file should trigger a decode error
+    let data: Vec<u8> = (0u8..20).collect();
+    let mut input = compress(&data, 3).unwrap();
+    input.truncate(4); // simulate a truncated stream
+    assert!(decompress_with_limit(&input, 100).is_err());
+}
+
+#[test]
+fn test_wrong_hash_fails_decompression() {
+    // Corrupting any byte should lead to a hash mismatch during decompression
+    let data: Vec<u8> = (0u8..10).collect();
+    let mut input = compress(&data, 3).unwrap();
+    input[2] ^= 0xFF; // flip a byte in the stream
+    assert!(decompress_with_limit(&input, 100).is_err());
+}

--- a/tests/header_roundtrip.rs
+++ b/tests/header_roundtrip.rs
@@ -1,0 +1,21 @@
+use telomere::{Header, encode_header, decode_header};
+use quickcheck::quickcheck;
+
+#[test]
+fn test_literal_header_encode_decode_roundtrip() {
+    // Encoding then decoding a literal header should return the same variant
+    let header = Header::Literal;
+    let encoded = encode_header(&header).unwrap();
+    let (decoded, _) = decode_header(&encoded).unwrap();
+    assert_eq!(header, decoded);
+}
+
+quickcheck! {
+    fn arity_header_roundtrip(arity: u8) -> bool {
+        // Arity is limited to 1-5 according to the spec
+        let arity = (arity % 5) + 1;
+        let header = Header::Arity(arity);
+        let encoded = encode_header(&header).unwrap();
+        matches!(decode_header(&encoded), Ok((decoded, _)) if decoded == header)
+    }
+}

--- a/tests/seed_index_mapping.rs
+++ b/tests/seed_index_mapping.rs
@@ -1,0 +1,25 @@
+use telomere::{seed_to_index, index_to_seed};
+
+const MAX_LEN: usize = 3;
+
+#[test]
+fn test_index_to_seed_roundtrip() {
+    // Converting an index to a seed and back should yield the same index
+    for i in 0..500 {
+        let seed = index_to_seed(i, MAX_LEN).unwrap();
+        let index = seed_to_index(&seed, MAX_LEN);
+        assert_eq!(index, i);
+    }
+}
+
+#[test]
+fn test_monotonic_index_generation() {
+    // Sequential indices should map back to increasing indices
+    let mut previous_index = 0usize;
+    for i in 1..1000 {
+        let seed = index_to_seed(i, MAX_LEN).unwrap();
+        let index = seed_to_index(&seed, MAX_LEN);
+        assert!(index > previous_index);
+        previous_index = index;
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests for block grouping and collapsing
- check header encode/decode with quickcheck
- verify compress roundtrip stability
- ensure seed index conversions stay monotonic
- validate decompression failure on corrupted inputs
- update `.gitignore` to track new tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c11d76b1c83298cf56e4235511661