### PR TITLE
Implement arity block decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ src/bin/seed_table.rs
 !tests/seed_index_mapping.rs
 !tests/decompress_validation.rs
 !tests/bundle_select.rs
+!tests/decode_arity_blocks.rs
 seed_table.csv
 run_table.bat
 table_24.csv

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,22 @@
+use std::collections::HashMap;
+
 pub struct Config {
     pub block_size: usize,
     pub max_seed_len: usize,
     pub max_arity: u8,
     pub hash_bits: usize,
+    /// Pre-expanded seed bitstreams indexed by seed index.
+    pub seed_expansions: HashMap<usize, Vec<u8>>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            block_size: 0,
+            max_seed_len: 0,
+            max_arity: 0,
+            hash_bits: 0,
+            seed_expansions: HashMap::new(),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,12 @@ mod tlmr;
 // implementation used precomputed decompressed strings to accelerate
 // seed matching.  Future versions may reintroduce a `gloss` module.
 mod block_indexer;
+mod bundle_select;
 mod candidate;
+mod config;
 mod hash_reader;
 mod header;
+mod hybrid;
 pub mod io_utils;
 mod live_window;
 mod path;
@@ -25,10 +28,8 @@ mod seed_detect;
 mod seed_index;
 mod seed_logger;
 mod sha_cache;
-mod hybrid;
 mod stats;
 pub mod superposition;
-mod bundle_select;
 pub mod types;
 use sha2::{Digest, Sha256};
 
@@ -39,15 +40,16 @@ pub use block::{
 };
 pub use block_indexer::{brute_force_seed_tables, IndexedBlock, SeedMatch};
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
+pub use bundle_select::{select_bundles, AcceptedBundle, BundleRecord};
 pub use candidate::{prune_candidates, Block as CandidateBlock, Candidate};
 pub use compress::{compress, compress_block, compress_multi_pass, TruncHashTable};
 pub use compress_stats::{write_stats_csv, CompressionStats};
-pub use hybrid::{compress_hybrid, CpuMatchRecord, GpuMatchRecord};
-pub use bundle_select::{select_bundles, AcceptedBundle, BundleRecord};
+pub use config::Config;
 pub use error::TelomereError;
 pub use file_header::{decode_file_header, encode_file_header};
 pub use hash_reader::lookup_seed;
-pub use header::{decode_header, encode_header, BitReader, Header};
+pub use header::{decode_header, decode_span, encode_header, BitReader, Header};
+pub use hybrid::{compress_hybrid, CpuMatchRecord, GpuMatchRecord};
 pub use io_utils::*;
 pub use live_window::{print_window, LiveStats};
 pub use path::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 max_seed_len: args.max_seed_len,
                 max_arity: args.max_arity,
                 hash_bits: args.hash_bits,
+                seed_expansions: std::collections::HashMap::new(),
             };
             let data = fs::read(&input_path)
                 .map_err(|e| io_cli_error("opening input file", &input_path, e))?;
@@ -83,6 +84,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 max_seed_len: args.max_seed_len,
                 max_arity: args.max_arity,
                 hash_bits: args.hash_bits,
+                seed_expansions: std::collections::HashMap::new(),
             };
             if input_path
                 .extension()

--- a/tests/decode_arity_blocks.rs
+++ b/tests/decode_arity_blocks.rs
@@ -1,0 +1,86 @@
+use telomere::{decode_span, encode_header, BitReader, Config, Header};
+
+fn pack_bits(bits: &[bool]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut byte = 0u8;
+    let mut used = 0u8;
+    for &b in bits {
+        byte = (byte << 1) | b as u8;
+        used += 1;
+        if used == 8 {
+            out.push(byte);
+            byte = 0;
+            used = 0;
+        }
+    }
+    if used > 0 {
+        byte <<= 8 - used;
+        out.push(byte);
+    }
+    if out.is_empty() {
+        out.push(0);
+    }
+    out
+}
+
+fn encode_arity(arity: usize) -> Vec<bool> {
+    assert!(arity >= 1);
+    let mut bits = Vec::new();
+    if arity == 1 {
+        bits.push(false);
+        return bits;
+    }
+    bits.push(true);
+    let index = arity - 1;
+    let digit = index % 3;
+    let reps = index / 3;
+    for _ in 0..reps {
+        bits.extend_from_slice(&[true, true]);
+    }
+    match digit {
+        0 => bits.extend_from_slice(&[false, false]),
+        1 => bits.extend_from_slice(&[false, true]),
+        2 => bits.extend_from_slice(&[true, false]),
+        _ => unreachable!(),
+    }
+    bits
+}
+
+fn encode_evql_bits(value: usize) -> Vec<bool> {
+    let mut width = 1usize;
+    let mut n = 0usize;
+    while width < usize::BITS as usize && value >= (1usize << width) {
+        width <<= 1;
+        n += 1;
+    }
+    let mut bits = Vec::new();
+    for _ in 0..n {
+        bits.push(true);
+    }
+    bits.push(false);
+    for i in (0..width).rev() {
+        bits.push(((value >> i) & 1) != 0);
+    }
+    bits
+}
+
+#[test]
+fn decode_seed_arity_stream() {
+    let block = vec![1u8, 2, 3];
+    let mut config = Config::default();
+    config.block_size = block.len();
+    config.seed_expansions.insert(0, {
+        let mut b = Vec::new();
+        b.extend_from_slice(&encode_header(&Header::Literal).unwrap());
+        b.extend_from_slice(&block);
+        b
+    });
+
+    let mut bits = encode_arity(1);
+    bits.extend(encode_evql_bits(0));
+    let stream = pack_bits(&bits);
+
+    let mut reader = BitReader::from_slice(&stream);
+    let out = decode_span(&mut reader, &config).unwrap();
+    assert_eq!(out, block);
+}


### PR DESCRIPTION
## Summary
- expose `Config` from the library and add seed_expansions with `Default`
- implement `decode_span` for recursive arity decoding
- add helper `align_byte` and EVQL decoding to header reader
- wire Config usage in CLI
- test decoding of a seed‑derived arity stream

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687c2c935d5c83298a125d83a4b1deeb