### PR TITLE
Implement arity bound check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ src/bin/seed_table.rs
 !tests/decompress_validation.rs
 !tests/bundle_select.rs
 !tests/decode_arity_blocks.rs
+!tests/compress_bounds.rs
 seed_table.csv
 run_table.bat
 table_24.csv

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -77,6 +77,9 @@ pub fn compress(data: &[u8], block_size: usize) -> Result<Vec<u8>, TelomereError
         let max_bundle = (remaining / block_size).min(MAX_ARITY);
         let mut matched = false;
         for arity in (1..=max_bundle).rev() {
+            if offset + arity * block_size > data.len() {
+                continue;
+            }
             if arity == 2 {
                 continue;
             }

--- a/tests/compress_bounds.rs
+++ b/tests/compress_bounds.rs
@@ -1,0 +1,41 @@
+use telomere::{compress, decode_header, decode_tlmr_header, decompress_with_limit, Header};
+
+#[test]
+fn partial_seed_block_falls_back_to_literal() {
+    let block_size = 3usize;
+    // 1.5 blocks of data derived from a known seed pattern
+    let mut data = vec![0u8; block_size];
+    data.push(0x01);
+
+    let compressed = compress(&data, block_size).unwrap();
+    let hdr = decode_tlmr_header(&compressed).unwrap();
+    assert_eq!(hdr.block_size, block_size);
+
+    // Decode body to inspect headers
+    let mut offset = 3usize; // skip file header
+    let mut headers = Vec::new();
+    while offset < compressed.len() {
+        let slice = &compressed[offset..];
+        let (h, bits) = decode_header(slice).unwrap();
+        headers.push(h);
+        offset += (bits + 7) / 8;
+        if let Header::Literal = headers.last().unwrap() {
+            let remaining = compressed.len() - offset;
+            let bytes = if remaining == hdr.last_block_size {
+                hdr.last_block_size
+            } else {
+                block_size
+            };
+            offset += bytes;
+        }
+    }
+
+    // Expect two literal blocks: the partial tail shouldn't be compressed
+    assert_eq!(headers.len(), 2);
+    assert!(matches!(headers[0], Header::Literal));
+    assert!(matches!(headers[1], Header::Literal));
+
+    // Ensure roundtrip works
+    let decompressed = decompress_with_limit(&compressed, usize::MAX).unwrap();
+    assert_eq!(decompressed, data);
+}


### PR DESCRIPTION
## Summary
- guard encoder against over-reading by checking arity window
- add regression test for near-EOF compression
- keep new test file tracked by `.gitignore`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c3b4cd5a4832994a896ab616fffe3