### PR TITLE
Implement tiling and GPU stub with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ src/bin/seed_table.rs
 !tests/decode_arity_blocks.rs
 !tests/compress_multi_pass.rs
 !tests/compress_bounds.rs
+!src/gpu.rs
+!src/tile.rs
+!tests/gpu_tiling.rs
 seed_table.csv
 run_table.bat
 table_24.csv

--- a/README.md
+++ b/README.md
@@ -149,3 +149,14 @@ nested segments as a recursive convergence goal.
 - ✅ Deterministic compression and literal passthrough format complete
 - ✅ Round-trip identity supported
 - 🔜 Seed-driven decoding (G-based) in development
+
+## GPU Accelerated Matching and Block Tiling
+
+The experimental hybrid pipeline splits the global block table into fixed-size
+tiles that can be loaded into RAM or VRAM on demand. Each tile records the
+global index of its first block so match logs can always refer to stable global
+indices. When the GPU begins a pass it hashes seeds over the currently loaded
+tile and reports only the compact match log back to the CPU. The CPU processes
+shorter seeds in parallel and merges the results when both complete.  All block
+tables are kept in sync after every pass so the next round starts from an
+identical state.

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,0 +1,53 @@
+use crate::block::Block;
+use crate::{GpuMatchRecord, TelomereError};
+use sha2::{Digest, Sha256};
+
+/// Simple CPU-based simulation of the GPU seed matcher.
+#[derive(Default)]
+pub struct GpuSeedMatcher {
+    tile: Vec<Block>,
+}
+
+impl GpuSeedMatcher {
+    /// Create a new matcher with an empty tile.
+    pub fn new() -> Self {
+        Self { tile: Vec::new() }
+    }
+
+    /// Load a block tile into the simulated GPU memory.
+    pub fn load_tile(&mut self, blocks: &[Block]) {
+        self.tile = blocks.to_vec();
+    }
+
+    /// Hash seeds on the fly and return match records.
+    pub fn seed_match(&self, start_seed: usize, end_seed: usize) -> Result<Vec<GpuMatchRecord>, TelomereError> {
+        let mut out = Vec::new();
+        for seed in start_seed..end_seed {
+            let seed_byte = seed as u8;
+            for block in &self.tile {
+                let expanded = expand_seed(&[seed_byte], block.data.len());
+                if expanded == block.data {
+                    out.push(GpuMatchRecord {
+                        seed_index: seed,
+                        bundle_length: 1,
+                        block_indices: vec![block.global_index],
+                        original_bits: block.bit_length,
+                    });
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn expand_seed(seed: &[u8], len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut cur = seed.to_vec();
+    while out.len() < len {
+        let digest: [u8; 32] = Sha256::digest(&cur).into();
+        out.extend_from_slice(&digest);
+        cur = digest.to_vec();
+    }
+    out.truncate(len);
+    out
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ mod seed_detect;
 mod seed_index;
 mod seed_logger;
 mod sha_cache;
+mod tile;
+mod gpu;
 mod stats;
 pub mod superposition;
 pub mod types;
@@ -59,6 +61,8 @@ pub use seed_logger::{
     log_seed, log_seed_to, resume_seed_index, resume_seed_index_from, HashEntry, ResourceLimits,
 };
 pub use sha_cache::*;
+pub use tile::{BlockChunk, TileMap, chunk_blocks, flush_chunk, load_chunk};
+pub use gpu::GpuSeedMatcher;
 pub use stats::Stats;
 pub use tlmr::{decode_tlmr_header, encode_tlmr_header, truncated_hash, TlmrError, TlmrHeader};
 

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,0 +1,61 @@
+use crate::block::Block;
+use crate::TelomereError;
+
+/// A contiguous chunk of the global block table.
+///
+/// `start_index` records the global index of the first block in `blocks`.
+#[derive(Debug, Clone)]
+pub struct BlockChunk {
+    pub start_index: usize,
+    pub blocks: Vec<Block>,
+}
+
+/// Map global block indices to tiled chunks.
+#[derive(Debug, Clone)]
+pub struct TileMap {
+    total_blocks: usize,
+    chunk_size: usize,
+}
+
+impl TileMap {
+    /// Create a new `TileMap` covering `total_blocks` blocks.
+    pub fn new(total_blocks: usize, chunk_size: usize) -> Self {
+        Self { total_blocks, chunk_size }
+    }
+
+    /// Number of chunks implied by this map.
+    pub fn chunk_count(&self) -> usize {
+        if self.total_blocks == 0 { 0 } else { (self.total_blocks - 1) / self.chunk_size + 1 }
+    }
+
+    /// Map a global block index to `(chunk, offset)`.
+    pub fn map_global(&self, index: usize) -> Option<(usize, usize)> {
+        if index >= self.total_blocks { return None; }
+        let chunk = index / self.chunk_size;
+        let offset = index % self.chunk_size;
+        Some((chunk, offset))
+    }
+}
+
+/// Split a flat block list into tiled chunks.
+pub fn chunk_blocks(blocks: &[Block], chunk_size: usize) -> Vec<BlockChunk> {
+    let mut chunks = Vec::new();
+    let mut idx = 0usize;
+    while idx < blocks.len() {
+        let end = (idx + chunk_size).min(blocks.len());
+        let slice = blocks[idx..end].to_vec();
+        chunks.push(BlockChunk { start_index: idx, blocks: slice });
+        idx = end;
+    }
+    chunks
+}
+
+/// Load a chunk from a pre-split vector.
+pub fn load_chunk(chunks: &[BlockChunk], index: usize) -> Result<BlockChunk, TelomereError> {
+    chunks.get(index).cloned().ok_or_else(|| TelomereError::Other("invalid chunk".into()))
+}
+
+/// No-op flush helper for the in-memory tiling tests.
+pub fn flush_chunk(_chunk: BlockChunk) -> Result<(), TelomereError> {
+    Ok(())
+}

--- a/tests/gpu_tiling.rs
+++ b/tests/gpu_tiling.rs
@@ -1,0 +1,56 @@
+use telomere::{
+    chunk_blocks, load_chunk, TileMap, GpuSeedMatcher, split_into_blocks,
+};
+
+#[test]
+fn block_chunk_mapping() {
+    let input: Vec<u8> = (0u8..64).collect();
+    let blocks = split_into_blocks(&input, 8); // 1 byte per block
+    let chunks = chunk_blocks(&blocks, 10);
+    assert_eq!(chunks.len(), 7);
+    let map = TileMap::new(blocks.len(), 10);
+    assert_eq!(map.map_global(0), Some((0, 0)));
+    assert_eq!(map.map_global(15), Some((1, 5)));
+    assert_eq!(map.map_global(63), Some((6, 3)));
+    let c3 = load_chunk(&chunks, 3).unwrap();
+    assert_eq!(c3.start_index, 30);
+    assert_eq!(c3.blocks.len(), 10);
+}
+
+#[test]
+fn gpu_seed_match_stub() {
+    let input: Vec<u8> = (0u8..16).collect();
+    let blocks = split_into_blocks(&input, 8); // 1 byte blocks
+    let mut matcher = GpuSeedMatcher::new();
+    matcher.load_tile(&blocks);
+    let gpu_matches = matcher.seed_match(0, 16).unwrap();
+    // brute force on CPU for comparison
+    let mut cpu_matches = Vec::new();
+    for seed in 0usize..16 {
+        let seed_byte = seed as u8;
+        for block in &blocks {
+            let expanded = expand_seed(&[seed_byte], block.data.len());
+            if expanded == block.data {
+                cpu_matches.push((seed, block.global_index));
+            }
+        }
+    }
+    let gpu_flat: Vec<(usize, usize)> = gpu_matches
+        .iter()
+        .map(|r| (r.seed_index, r.block_indices[0]))
+        .collect();
+    assert_eq!(cpu_matches, gpu_flat);
+}
+
+fn expand_seed(seed: &[u8], len: usize) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut out = Vec::with_capacity(len);
+    let mut cur = seed.to_vec();
+    while out.len() < len {
+        let digest: [u8; 32] = Sha256::digest(&cur).into();
+        out.extend_from_slice(&digest);
+        cur = digest.to_vec();
+    }
+    out.truncate(len);
+    out
+}


### PR DESCRIPTION
## Summary
- add in-memory block tiling helpers
- introduce a CPU based GPU matcher stub
- expose the new modules from the library
- document GPU/CPU tiling design in README
- test chunk mapping and GPU stub operation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687c4a867f6c83299871463a1212a00c