### PR TITLE
Improve multi-pass compression

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .map_err(|e| io_cli_error("opening input file", &input_path, e))?;
 
             let start_time = Instant::now();
-            let out = compress_multi_pass(&data, config.block_size, args.passes)
+            let (out, gains) = compress_multi_pass(&data, config.block_size, args.passes)
                 .map_err(|e| simple_cli_error(&format!("compression failed: {e}")))?;
 
             if out.is_empty() {
@@ -70,9 +70,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     "input_bytes": raw_len,
                     "compressed_bytes": compressed_len,
                     "elapsed_ms": elapsed.as_millis(),
+                    "gains": gains,
                 });
                 println!("{}", serde_json::to_string_pretty(&out_json).unwrap());
             } else if args.status {
+                for (idx, gain) in gains.iter().enumerate() {
+                    eprintln!("pass {} gained {} bytes", idx + 2, gain);
+                }
                 eprintln!("Compressed {:.2}% in {:.2?}", percent, elapsed);
             }
         }

--- a/tests/compress_multi_pass.rs
+++ b/tests/compress_multi_pass.rs
@@ -1,10 +1,33 @@
 use telomere::{compress, compress_multi_pass, expand_seed};
 
 #[test]
-fn multi_pass_converges() {
-    let block_size = 3usize;
-    let data = expand_seed(&[0u8], block_size * 3);
-    let single = compress(&data, block_size).unwrap();
-    let multi = compress_multi_pass(&data, block_size, 5).unwrap();
+fn multi_pass_converges_without_gain() {
+    let block = 3usize;
+    let data = expand_seed(&[0u8], block * 3);
+    let single = compress(&data, block).unwrap();
+    let (multi, gains) = compress_multi_pass(&data, block, 5).unwrap();
     assert_eq!(single, multi);
+    assert!(gains.is_empty());
+}
+
+#[test]
+fn random_input_never_grows() {
+    let block = 3usize;
+    let mut data = expand_seed(&[2u8], block * 2);
+    data.extend_from_slice(&[1, 2, 3]);
+    let single = compress(&data, block).unwrap();
+    let (multi, gains) = compress_multi_pass(&data, block, 3).unwrap();
+    assert!(multi.len() <= single.len());
+    assert!(gains.iter().all(|&g| g > 0));
+}
+
+#[test]
+fn repeated_seeds_gain_over_single_pass() {
+    let block = 3usize;
+    let mut data = expand_seed(&[1u8], block * 2);
+    data.extend_from_slice(&expand_seed(&[1u8], block * 2));
+    let single = compress(&data, block).unwrap();
+    let (multi, gains) = compress_multi_pass(&data, block, 3).unwrap();
+    assert!(multi.len() <= single.len());
+    assert!(!gains.is_empty());
 }

--- a/tests/full_roundtrip_audit.rs
+++ b/tests/full_roundtrip_audit.rs
@@ -7,7 +7,7 @@ fn full_roundtrip_audit() {
     data.extend_from_slice(&[1, 2, 3, 4, 5]);
 
     // Compress through multi-pass pipeline.
-    let compressed = compress_multi_pass(&data, block_size, 3).unwrap();
+    let (compressed, _) = compress_multi_pass(&data, block_size, 3).unwrap();
 
     // Decompress back to original bytes.
     let decoded = decompress(&compressed).unwrap();


### PR DESCRIPTION
## Summary
- implement detailed logging and gain tracking in `compress_multi_pass`
- expose pass gains in CLI and JSON output
- update tests for multi-pass behaviour

## Testing
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_687c58f121248329989b35ca8beff72f