### PR TITLE
Add extensive roundtrip and adversarial tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ src/bin/seed_table.rs
 !tests/decode_arity_blocks.rs
 !tests/compress_multi_pass.rs
 !tests/compress_bounds.rs
+!tests/full_roundtrip_audit.rs
+!tests/adversarial_prop.rs
 !src/gpu.rs
 !src/tile.rs
 !tests/gpu_tiling.rs

--- a/tests/adversarial_prop.rs
+++ b/tests/adversarial_prop.rs
@@ -1,0 +1,70 @@
+use proptest::prelude::*;
+use telomere::{compress, decompress};
+
+fn alternating(len: usize) -> Vec<u8> {
+    (0..len).map(|i| if i % 2 == 0 {0x00} else {0xFF}).collect()
+}
+
+fn palindrome(data: Vec<u8>) -> Vec<u8> {
+    let mut out = data.clone();
+    out.extend(data.into_iter().rev());
+    out
+}
+
+proptest! {
+    #[test]
+    fn zeros_roundtrip(len in 0usize..64, bs in 1usize..8) {
+        let data = vec![0u8; len];
+        let c = compress(&data, bs).unwrap();
+        let out = decompress(&c).unwrap();
+        prop_assert_eq!(out, data);
+    }
+
+    #[test]
+    fn ones_roundtrip(len in 0usize..64, bs in 1usize..8) {
+        let data = vec![0xFFu8; len];
+        let c = compress(&data, bs).unwrap();
+        let out = decompress(&c).unwrap();
+        prop_assert_eq!(out, data);
+    }
+
+    #[test]
+    fn alternating_roundtrip(len in 0usize..64, bs in 1usize..8) {
+        let data = alternating(len);
+        let c = compress(&data, bs).unwrap();
+        let out = decompress(&c).unwrap();
+        prop_assert_eq!(out, data);
+    }
+
+    #[test]
+    fn palindrome_roundtrip(data in proptest::collection::vec(any::<u8>(), 0..32), bs in 1usize..8) {
+        let data = palindrome(data);
+        let c = compress(&data, bs).unwrap();
+        let out = decompress(&c).unwrap();
+        prop_assert_eq!(out, data);
+    }
+
+    #[test]
+    fn random_block_alignment(data in proptest::collection::vec(any::<u8>(), 0..64), bs in 1usize..8, pad in 0usize..8) {
+        let mut d = data;
+        d.extend(vec![0u8; pad]);
+        let c = compress(&d, bs).unwrap();
+        let out = decompress(&c).unwrap();
+        prop_assert_eq!(out, d);
+    }
+
+    #[test]
+    fn decode_never_panics(data in proptest::collection::vec(any::<u8>(), 0..80)) {
+        let _ = std::panic::catch_unwind(|| { let _ = decompress(&data); }).ok();
+    }
+}
+
+#[test]
+fn literal_torture() {
+    let block_size = 3usize;
+    let len = block_size * 10 + 1;
+    let data: Vec<u8> = (0..len as u8).collect();
+    let c = compress(&data, block_size).unwrap();
+    let out = decompress(&c).unwrap();
+    assert_eq!(out, data);
+}

--- a/tests/full_roundtrip_audit.rs
+++ b/tests/full_roundtrip_audit.rs
@@ -1,4 +1,12 @@
-use telomere::{compress_multi_pass, decompress, expand_seed};
+use telomere::{
+    compress,
+    compress_multi_pass,
+    decompress,
+    decode_header,
+    decode_tlmr_header,
+    expand_seed,
+    Header,
+};
 
 #[test]
 fn full_roundtrip_audit() {
@@ -12,4 +20,80 @@ fn full_roundtrip_audit() {
     // Decompress back to original bytes.
     let decoded = decompress(&compressed).unwrap();
     assert_eq!(decoded, data);
+}
+
+#[test]
+fn single_block_literal_roundtrip() {
+    let block_size = 4usize;
+    let data = vec![0xAB, 0xCD, 0xEF, 0x01];
+    let compressed = compress(&data, block_size).unwrap();
+    let header = decode_tlmr_header(&compressed).unwrap();
+    assert_eq!(header.block_size, block_size);
+    let _ = decode_header(&compressed[3..]).unwrap();
+    let out = decompress(&compressed).unwrap();
+    assert_eq!(out, data);
+}
+
+#[test]
+fn multi_block_mixed_roundtrip() {
+    let block_size = 3usize;
+    let mut data = expand_seed(&[1u8], block_size * 3);
+    data.extend_from_slice(&[0x10, 0x20, 0x30]);
+    let compressed = compress(&data, block_size).unwrap();
+    let hdr = decode_tlmr_header(&compressed).unwrap();
+    assert_eq!(hdr.block_size, block_size);
+    let mut offset = 3usize;
+    while offset < compressed.len() {
+        let (h, bits) = decode_header(&compressed[offset..]).unwrap();
+        offset += (bits + 7) / 8;
+        match h {
+            Header::Literal => {
+                let remaining = compressed.len() - offset;
+                let bytes = if remaining == hdr.last_block_size {
+                    hdr.last_block_size
+                } else {
+                    block_size
+                };
+                offset += bytes;
+            }
+            Header::Arity(_) => {
+                // Skip EVQL bits for the seed index
+                offset += 1; // at least one byte is present
+            }
+        }
+    }
+    assert_eq!(offset, compressed.len());
+    let out = decompress(&compressed).unwrap();
+    assert_eq!(out, data);
+}
+
+#[test]
+fn partial_compressible_roundtrip() {
+    let block_size = 3usize;
+    let mut data = expand_seed(&[0u8], block_size);
+    data.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+    data.extend_from_slice(&expand_seed(&[0u8], block_size));
+    let compressed = compress(&data, block_size).unwrap();
+    let out = decompress(&compressed).unwrap();
+    assert_eq!(out, data);
+}
+
+#[test]
+fn large_file_roundtrip() {
+    let block_size = 4usize;
+    let data = expand_seed(&[2u8], 1_000_000);
+    let compressed = compress(&data, block_size).unwrap();
+    let out = decompress(&compressed).unwrap();
+    assert_eq!(out.len(), data.len());
+    assert_eq!(out[0..16], data[0..16]);
+    assert_eq!(out.last(), data.last());
+}
+
+#[test]
+fn single_byte_roundtrip() {
+    let block_size = 1usize;
+    let data = vec![0x7F];
+    let compressed = compress(&data, block_size).unwrap();
+    let out = decompress(&compressed).unwrap();
+    assert_eq!(out, data);
 }


### PR DESCRIPTION
## Summary
- expand `full_roundtrip_audit.rs` with multiple encode→decode checks
- add `adversarial_prop.rs` for property based fuzz style testing
- whitelist new test files in `.gitignore`

## Testing
- `timeout 40s cargo test single_block_literal_roundtrip -- --quiet` *(fails: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_687c5993b1708329801d31189a968886