### PR TITLE
Activate superposition pass pruning

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,7 +1,7 @@
 use crate::compress_stats::CompressionStats;
 use crate::header::{encode_arity_bits, encode_evql_bits, encode_header, Header};
 use crate::seed::find_seed_match;
-use crate::seed_index::index_to_seed;
+use crate::superposition::SuperpositionManager;
 use crate::tlmr::{encode_tlmr_header, truncated_hash, TlmrHeader};
 use crate::TelomereError;
 
@@ -92,31 +92,124 @@ pub fn compress(data: &[u8], block_size: usize) -> Result<Vec<u8>, TelomereError
 /// Returns the final compressed bytes along with a vector recording the number
 /// of bytes saved after each *successful* pass.  The first element corresponds
 /// to the second pass since the initial invocation is considered pass `1`.
+///
+/// All candidate matches for a given block are inserted into the
+/// [`SuperpositionManager`] during the pass without pruning. After the entire
+/// input has been processed, superpositions are pruned so that only the
+/// shortest candidate per block remains. The block table is therefore
+/// immutable during a pass and only updated at pass boundaries.
 pub fn compress_multi_pass(
     data: &[u8],
     block_size: usize,
     max_passes: usize,
 ) -> Result<(Vec<u8>, Vec<usize>), TelomereError> {
-    let mut current = compress(data, block_size)?;
+    let mut current = data.to_vec();
     let mut gains = Vec::new();
-    let mut passes = 1usize;
+    let mut passes = 0usize;
+
+    const MAX_ARITY: usize = 6;
+    const MAX_SEED_LEN: usize = 3;
 
     while passes < max_passes {
-        let next = compress(&current, block_size)?;
-        let saved = current.len().saturating_sub(next.len());
-        if saved > 0 {
-            eprintln!("pass {} gained {} bytes", passes + 1, saved);
-            gains.push(saved);
-            current = next;
-            passes += 1;
-        } else {
-            eprintln!("converged after {} passes", passes);
-            return Ok((current, gains));
-        }
-    }
+        passes += 1;
+        let mut mgr = SuperpositionManager::new();
 
-    if passes == max_passes {
-        eprintln!("stopped after {} passes (pass cap)", passes);
+        // Split the current stream into fixed sized blocks.
+        let mut blocks: Vec<&[u8]> = Vec::new();
+        let mut offset = 0usize;
+        while offset < current.len() {
+            let end = (offset + block_size).min(current.len());
+            blocks.push(&current[offset..end]);
+            offset += block_size;
+        }
+
+        // Insert all candidates for each block index.
+        for (idx, _slice) in blocks.iter().enumerate() {
+            // Literal candidate always exists.
+            let lit_bits = _slice.len() * 8 + 3;
+            mgr.push_unpruned(
+                idx,
+                crate::types::Candidate {
+                    seed_index: usize::MAX as u64,
+                    arity: 1,
+                    bit_len: lit_bits,
+                },
+            );
+
+            // Seed matches for spans starting at this block.
+            let remaining = current.len().saturating_sub(idx * block_size);
+            let max_bundle = (remaining / block_size).min(MAX_ARITY);
+            for arity in 1..=max_bundle {
+                if arity == 2 {
+                    continue; // reserved for literal marker
+                }
+                let span_start = idx * block_size;
+                let span_end = span_start + arity * block_size;
+                if span_end > current.len() {
+                    break;
+                }
+                let span = &current[span_start..span_end];
+                if let Some(seed_idx) = find_seed_match(span, MAX_SEED_LEN)? {
+                    let header_bits = encode_arity_bits(arity)?;
+                    let evql_bits = encode_evql_bits(seed_idx);
+                    let total_bits = header_bits.len() + evql_bits.len();
+                    if (total_bits + 7) / 8 < span.len() {
+                        mgr.push_unpruned(
+                            idx,
+                            crate::types::Candidate {
+                                seed_index: seed_idx as u64,
+                                arity: arity as u8,
+                                bit_len: total_bits,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        mgr.prune_end_of_pass();
+
+        // Build the next compressed stream from the pruned candidates.
+        let last_block = if current.is_empty() {
+            block_size
+        } else {
+            (current.len() - 1) % block_size + 1
+        };
+        let header = encode_tlmr_header(&TlmrHeader {
+            version: 0,
+            block_size,
+            last_block_size: last_block,
+            output_hash: truncated_hash(&current),
+        });
+        let mut next = header.to_vec();
+
+        let mut i = 0usize;
+        while i < blocks.len() {
+            let cand = mgr.best_superposed(i).unwrap();
+            if cand.seed_index == usize::MAX as u64 {
+                // literal
+                next.extend_from_slice(&encode_header(&Header::Literal)?);
+                next.extend_from_slice(blocks[i]);
+                i += 1;
+            } else {
+                let arity = cand.arity as usize;
+                let span_start = i * block_size;
+                let _span_end = span_start + arity * block_size;
+                let header_bits = encode_arity_bits(arity)?;
+                let mut bits = header_bits;
+                bits.extend(encode_evql_bits(cand.seed_index as usize));
+                next.extend(pack_bits(&bits));
+                i += arity;
+                // bytes themselves are reconstructed from seed, so nothing appended
+            }
+        }
+
+        let saved = current.len().saturating_sub(next.len());
+        if saved == 0 {
+            break;
+        }
+        gains.push(saved);
+        current = next;
     }
 
     Ok((current, gains))

--- a/tests/large_file_perf.rs
+++ b/tests/large_file_perf.rs
@@ -12,7 +12,8 @@ fn profile_case(name: &str, data: Vec<u8>) {
     let before_mem = sys.process(pid).map(|p| p.memory()).unwrap_or(0);
 
     let start = Instant::now();
-    let compressed = compress_multi_pass(&data, block_size, 3).expect("compress");
+    let (compressed, _gains) =
+        compress_multi_pass(&data, block_size, 3).expect("compress");
     let comp_time = start.elapsed();
     sys.refresh_process(pid);
     let after_comp_mem = sys.process(pid).map(|p| p.memory()).unwrap_or(0);

--- a/tests/superposition.rs
+++ b/tests/superposition.rs
@@ -275,6 +275,18 @@ fn superposed_fourth_prunes_longest() {
     assert!(list.iter().any(|(l, c)| *l == 'C' && c.bit_len == better.bit_len));
 }
 
+#[test]
+fn prune_end_of_pass_keeps_shortest() {
+    let mut mgr = SuperpositionManager::new();
+    mgr.push_unpruned(0, Candidate { seed_index: 1, arity: 1, bit_len: 30 });
+    mgr.push_unpruned(0, Candidate { seed_index: 2, arity: 1, bit_len: 28 });
+    mgr.push_unpruned(0, Candidate { seed_index: 3, arity: 1, bit_len: 28 });
+    mgr.prune_end_of_pass();
+    let list = mgr.all_superposed().into_iter().find(|(i, _)| *i == 0).unwrap().1;
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].1.bit_len, 28);
+}
+
 proptest::proptest! {
     #[test]
     fn superposition_invariants(bit_lens in proptest::collection::vec(8usize..40, 1..10)) {


### PR DESCRIPTION
## Summary
- integrate `SuperpositionManager` into `compress_multi_pass`
- add end-of-pass pruning utilities
- fix ignored compile error in `large_file_perf`
- test pruning behaviour

## Testing
- `cargo check --quiet`
- `cargo test prune_end_of_pass_keeps_shortest -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_687c7ff8044883299f9bf0c6d73943ec