### PR TITLE
Add property test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ run_table.bat
 table_24.csv
 table_32.csv
 !tests/large_file_perf.rs
+!tests/property_matrix.rs

--- a/tests/property_matrix.rs
+++ b/tests/property_matrix.rs
@@ -1,0 +1,70 @@
+use proptest::prelude::*;
+use telomere::{compress, compress_multi_pass, decompress};
+use telomere::superposition::SuperpositionManager;
+use telomere::types::Candidate;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
+    // Round-trip fuzz across bundling modes
+    #[test]
+    fn roundtrip_fuzz(data in proptest::collection::vec(any::<u8>(), 32..257),
+                      block in 2usize..8,
+                      passes in 1usize..4,
+                      bundling in proptest::bool::ANY) {
+        let compressed = if bundling {
+            compress_multi_pass(&data, block, passes).unwrap().0
+        } else {
+            compress(&data, block).unwrap()
+        };
+        let out = decompress(&compressed).unwrap();
+        prop_assert_eq!(out.as_slice(), data.as_slice());
+        prop_assert!(compressed.len() <= data.len() + 8);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
+    // Superposition pruning keeps only the smallest candidate
+    #[test]
+    fn superposition_minimality(bit_lens in proptest::collection::vec(8usize..64, 1..8)) {
+        let mut mgr = SuperpositionManager::new();
+        for (i, len) in bit_lens.iter().enumerate() {
+            mgr.push_unpruned(0, Candidate { seed_index: i as u64, arity: 1, bit_len: *len });
+        }
+        mgr.prune_end_of_pass();
+        let list = mgr.all_superposed().into_iter().find(|(i, _)| *i == 0).unwrap().1;
+        let min = *bit_lens.iter().min().unwrap();
+        prop_assert_eq!(list.len(), 1);
+        prop_assert_eq!(list[0].1.bit_len, min);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
+    // Compressing the same data twice yields identical output
+    #[test]
+    fn bundler_idempotence(data in proptest::collection::vec(any::<u8>(), 32..257),
+                           block in 2usize..8,
+                           passes in 1usize..4) {
+        let (first, _) = compress_multi_pass(&data, block, passes).unwrap();
+        let (second, _) = compress_multi_pass(&data, block, passes).unwrap();
+        prop_assert_eq!(first, second);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
+    // Bit flips invalidate the compressed stream
+    #[test]
+    fn fuzzed_headers(data in proptest::collection::vec(any::<u8>(), 32..128),
+                      block in 2usize..8,
+                      bit in 0usize..1000) {
+        let compressed = compress(&data, block).unwrap();
+        if compressed.is_empty() { return Ok(()); }
+        let total_bits = compressed.len() * 8;
+        let idx = bit % total_bits;
+        let mut corrupt = compressed.clone();
+        corrupt[idx / 8] ^= 1 << (idx % 8);
+        prop_assert!(decompress(&corrupt).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add new property test suite covering multiple invariants
- allow new test file in `.gitignore`

## Testing
- `cargo test --test property_matrix -- --test-threads=1` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687c903452088329bc267c135391fde6