### PR TITLE
Enforce superposition coverage checks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,12 @@
 //! library APIs found in this crate.
 
 use clap::{ArgGroup, Args, Parser, Subcommand};
+use std::{error::Error, fs, path::PathBuf, time::Instant};
 use telomere::Config;
-use std::{fs, path::PathBuf, time::Instant};
 use telomere::{
-    compress_multi_pass, decompress_with_limit, decode_tlmr_header, truncated_hash,
-    io_utils::{
-        extension_error, io_cli_error, simple_cli_error, telomere_cli_error,
-        CliError,
-    },
+    compress_multi_pass, decode_tlmr_header, decompress_with_limit,
+    io_utils::{extension_error, io_cli_error, simple_cli_error, telomere_cli_error, CliError},
+    truncated_hash,
 };
 
 fn print_cli_error(err: &CliError) {
@@ -84,7 +82,11 @@ fn run() -> Result<(), CliError> {
             let elapsed = start_time.elapsed();
 
             if args.json {
-                let cfg = Config { block_size: args.block_size, hash_bits: args.hash_bits, ..Config::default() };
+                let cfg = Config {
+                    block_size: args.block_size,
+                    hash_bits: args.hash_bits,
+                    ..Config::default()
+                };
                 let (hash, err) = match decompress_with_limit(&out, &cfg, usize::MAX) {
                     Ok(bytes) => (truncated_hash(&bytes), None::<String>),
                     Err(e) => (0, Some(e.to_string())),
@@ -143,7 +145,11 @@ fn run() -> Result<(), CliError> {
             // Always decode header and use correct config to ensure strictness
             let header = decode_tlmr_header(&data)
                 .map_err(|e| simple_cli_error(&format!("invalid header: {e}")))?;
-            let cfg = Config { block_size: header.block_size, hash_bits: args.hash_bits, ..Config::default() };
+            let cfg = Config {
+                block_size: header.block_size,
+                hash_bits: args.hash_bits,
+                ..Config::default()
+            };
             let decompressed = decompress_with_limit(&data, &cfg, usize::MAX)
                 .map_err(|e| simple_cli_error(&format!("decompression failed: {e}")))?;
             if !args.dry_run {

--- a/src/tlmr.rs
+++ b/src/tlmr.rs
@@ -29,6 +29,12 @@ pub enum TlmrError {
     OutputHashMismatch,
 }
 
+impl From<&str> for TlmrError {
+    fn from(_: &str) -> Self {
+        TlmrError::InvalidField
+    }
+}
+
 /// Encode the Telomere header with protocol version 0.
 pub fn encode_tlmr_header(header: &TlmrHeader) -> [u8; 3] {
     assert!(header.version <= 7, "version out of range");

--- a/tests/property_matrix.rs
+++ b/tests/property_matrix.rs
@@ -1,7 +1,7 @@
 use proptest::prelude::*;
-use telomere::{compress, compress_multi_pass, decompress};
 use telomere::superposition::SuperpositionManager;
 use telomere::types::Candidate;
+use telomere::{compress, compress_multi_pass, decompress, Config};
 
 proptest! {
     #![proptest_config(ProptestConfig { cases: 16, .. ProptestConfig::default() })]
@@ -16,7 +16,7 @@ proptest! {
         } else {
             compress(&data, block).unwrap()
         };
-        let out = decompress(&compressed).unwrap();
+        let out = decompress(&compressed, &Config::default()).unwrap();
         prop_assert_eq!(out.as_slice(), data.as_slice());
         prop_assert!(compressed.len() <= data.len() + 8);
     }
@@ -27,7 +27,7 @@ proptest! {
     // Superposition pruning keeps only the smallest candidate
     #[test]
     fn superposition_minimality(bit_lens in proptest::collection::vec(8usize..64, 1..8)) {
-        let mut mgr = SuperpositionManager::new();
+        let mut mgr = SuperpositionManager::new(1);
         for (i, len) in bit_lens.iter().enumerate() {
             mgr.push_unpruned(0, Candidate { seed_index: i as u64, arity: 1, bit_len: *len });
         }
@@ -65,6 +65,6 @@ proptest! {
         let idx = bit % total_bits;
         let mut corrupt = compressed.clone();
         corrupt[idx / 8] ^= 1 << (idx % 8);
-        prop_assert!(decompress(&corrupt).is_err());
+        prop_assert!(decompress(&corrupt, &Config::default()).is_err());
     }
 }

--- a/tests/superposition.rs
+++ b/tests/superposition.rs
@@ -1,5 +1,6 @@
 //! See [Kolyma Spec](../kolyma.pdf) - 2025-07-20 - commit c48b123cf3a8761a15713b9bf18697061ab23976
-use telomere::superposition::{SuperpositionManager, InsertResult};
+use rand::seq::SliceRandom;
+use telomere::superposition::{InsertResult, SuperpositionManager};
 use telomere::types::Candidate;
 use telomere::{apply_block_changes, group_by_bit_length, Block, BlockChange, BranchStatus};
 
@@ -81,23 +82,56 @@ fn block_change_clears_branches() {
 
 #[test]
 fn superposed_label_promotion() {
-    let mut mgr = SuperpositionManager::new();
+    let mut mgr = SuperpositionManager::new(1);
 
     // Insert three candidates with varying bit_len.
-    let a = Candidate { seed_index: 1, arity: 1, bit_len: 24 };
-    let b = Candidate { seed_index: 2, arity: 1, bit_len: 29 };
-    let c = Candidate { seed_index: 3, arity: 1, bit_len: 31 };
+    let a = Candidate {
+        seed_index: 1,
+        arity: 1,
+        bit_len: 24,
+    };
+    let b = Candidate {
+        seed_index: 2,
+        arity: 1,
+        bit_len: 29,
+    };
+    let c = Candidate {
+        seed_index: 3,
+        arity: 1,
+        bit_len: 31,
+    };
 
-    assert_eq!(mgr.insert_superposed(0, a.clone()).unwrap(), InsertResult::Inserted('A'));
-    assert_eq!(mgr.insert_superposed(0, b.clone()).unwrap(), InsertResult::Inserted('B'));
-    assert_eq!(mgr.insert_superposed(0, c.clone()).unwrap(), InsertResult::Inserted('C'));
+    assert_eq!(
+        mgr.insert_superposed(0, a.clone()).unwrap(),
+        InsertResult::Inserted('A')
+    );
+    assert_eq!(
+        mgr.insert_superposed(0, b.clone()).unwrap(),
+        InsertResult::Inserted('B')
+    );
+    assert_eq!(
+        mgr.insert_superposed(0, c.clone()).unwrap(),
+        InsertResult::Inserted('C')
+    );
 
     // Insert a better candidate (bit_len < all previous)
-    let better = Candidate { seed_index: 4, arity: 1, bit_len: 23 };
-    assert_eq!(mgr.insert_superposed(0, better.clone()).unwrap(), InsertResult::Inserted('A'));
+    let better = Candidate {
+        seed_index: 4,
+        arity: 1,
+        bit_len: 23,
+    };
+    assert_eq!(
+        mgr.insert_superposed(0, better.clone()).unwrap(),
+        InsertResult::Inserted('A')
+    );
 
     // After pruning and relabeling, there should be three candidates, best is 'A'
-    let list = mgr.all_superposed().into_iter().find(|(i, _)| *i == 0).unwrap().1;
+    let list = mgr
+        .all_superposed()
+        .into_iter()
+        .find(|(i, _)| *i == 0)
+        .unwrap()
+        .1;
     assert_eq!(list.len(), 3);
 
     // The best (lowest bit_len) is 'A', must be 'better'
@@ -114,13 +148,26 @@ fn superposed_label_promotion() {
 fn superposed_prune_many() {
     use rand::{thread_rng, Rng};
     let mut rng = thread_rng();
-    let mut mgr = SuperpositionManager::new();
+    let mut mgr = SuperpositionManager::new(1);
     for i in 0..100u64 {
         let len = rng.gen_range(8..40);
-        mgr.insert_superposed(0, Candidate { seed_index: i, arity: 1, bit_len: len }).unwrap();
+        mgr.insert_superposed(
+            0,
+            Candidate {
+                seed_index: i,
+                arity: 1,
+                bit_len: len,
+            },
+        )
+        .unwrap();
     }
     mgr.prune_end_of_pass();
-    let list = mgr.all_superposed().into_iter().find(|(i, _)| *i == 0).unwrap().1;
+    let list = mgr
+        .all_superposed()
+        .into_iter()
+        .find(|(i, _)| *i == 0)
+        .unwrap()
+        .1;
     assert!(list.len() <= 3);
     assert_eq!(list[0].0, 'A');
     let best = list[0].1.bit_len;
@@ -128,7 +175,11 @@ fn superposed_prune_many() {
         assert!(c.bit_len - best <= 8);
     }
     let mut sorted = list.clone();
-    sorted.sort_by(|a, b| a.1.bit_len.cmp(&b.1.bit_len).then(a.1.seed_index.cmp(&b.1.seed_index)));
+    sorted.sort_by(|a, b| {
+        a.1.bit_len
+            .cmp(&b.1.bit_len)
+            .then(a.1.seed_index.cmp(&b.1.seed_index))
+    });
     assert_eq!(list, sorted);
 }
 
@@ -138,7 +189,7 @@ proptest::proptest! {
     #[test]
     fn order_independent(mut vals in proptest::collection::vec((8usize..40usize, 0u64..1000u64), 1..20)) {
         let original = vals.clone();
-        let mut mgr1 = SuperpositionManager::new();
+        let mut mgr1 = SuperpositionManager::new(1);
         for (len, seed) in original.iter() {
             mgr1.insert_superposed(0, Candidate { seed_index:*seed, arity:1, bit_len:*len }).unwrap();
         }
@@ -146,11 +197,66 @@ proptest::proptest! {
         let out1 = mgr1.all_superposed();
 
         vals.shuffle(&mut rand::thread_rng());
-        let mut mgr2 = SuperpositionManager::new();
+        let mut mgr2 = SuperpositionManager::new(1);
         for (len, seed) in vals {
             mgr2.insert_superposed(0, Candidate { seed_index:seed, arity:1, bit_len:len }).unwrap();
         }
         mgr2.prune_end_of_pass();
         prop_assert_eq!(out1, mgr2.all_superposed());
     }
+}
+
+#[test]
+fn immediate_delta_pruning() {
+    let mut mgr = SuperpositionManager::new(1);
+    let a = Candidate {
+        seed_index: 1,
+        arity: 1,
+        bit_len: 16,
+    };
+    let b = Candidate {
+        seed_index: 2,
+        arity: 1,
+        bit_len: 40,
+    };
+    assert_eq!(
+        mgr.insert_superposed(0, a.clone()).unwrap(),
+        InsertResult::Inserted('A')
+    );
+    assert_eq!(
+        mgr.insert_superposed(0, b.clone()).unwrap(),
+        InsertResult::Pruned
+    );
+    let list = mgr
+        .all_superposed()
+        .into_iter()
+        .find(|(i, _)| *i == 0)
+        .unwrap()
+        .1;
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].1.bit_len, a.bit_len);
+}
+
+#[test]
+fn gap_free_coverage_enforced() {
+    let mut mgr = SuperpositionManager::new(3);
+    mgr.insert_candidate(
+        (0, 3),
+        Candidate {
+            seed_index: 1,
+            arity: 3,
+            bit_len: 24,
+        },
+    )
+    .unwrap();
+    assert!(mgr
+        .insert_candidate(
+            (1, 2),
+            Candidate {
+                seed_index: 2,
+                arity: 2,
+                bit_len: 16
+            }
+        )
+        .is_err());
 }


### PR DESCRIPTION
## Summary
- add block count to `SuperpositionManager`
- verify gap-free canonical coverage at insert time
- expose debug dump helper
- bound check superposed insert
- adapt compression to new constructor
- support `TlmrError` conversion from `&str`
- adjust property tests and add new unit tests

## Testing
- `cargo test --no-run`
- `cargo test --quiet` *(failed: tests exceeded time limit)*

------
https://chatgpt.com/codex/tasks/task_e_687ca0a95c608329b25f53a6786fdb93