### PR TITLE
Implement recursive span decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ table_24.csv
 table_32.csv
 !tests/large_file_perf.rs
 !tests/property_matrix.rs
+!tests/decompress_spans.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ pub use block::{
 };
 pub use block_indexer::{brute_force_seed_tables, IndexedBlock, SeedMatch};
 pub use bundle::{apply_bundle, BlockStatus, MutableBlock};
-pub use bundler::bundle_one_layer;
 pub use bundle_select::{select_bundles, AcceptedBundle, BundleRecord};
+pub use bundler::bundle_one_layer;
 pub use candidate::{prune_candidates, Block as CandidateBlock, Candidate};
 pub use compress::{
     compress, compress_block, compress_block_with_config, compress_multi_pass,
@@ -126,10 +126,7 @@ pub fn decompress_with_limit(
         return Err(TelomereError::Header("header too short".into()));
     }
     let header = decode_tlmr_header(input)?;
-    if header.version != 0
-        || header.block_size != config.block_size
-        || config.hash_bits != 13
-    {
+    if header.version != 0 || header.block_size != config.block_size || config.hash_bits != 13 {
         return Err(TelomereError::Header("file header mismatch".into()));
     }
     let mut offset = 3usize;
@@ -144,12 +141,13 @@ pub fn decompress_with_limit(
         let slice = input
             .get(offset..)
             .ok_or_else(|| TelomereError::Header("orphan/truncated bits".into()))?;
-        let (header, bits) =
-            decode_header(slice).map_err(|_| TelomereError::Header("orphan/truncated bits".into()))?;
-        offset += (bits + 7) / 8;
-        bits_consumed += bits;
+        let (header, bits) = decode_header(slice)
+            .map_err(|_| TelomereError::Header("orphan/truncated bits".into()))?;
+        let byte_len = (bits + 7) / 8;
         match header {
             Header::Literal => {
+                offset += byte_len;
+                bits_consumed += byte_len * 8;
                 let remaining = input.len() - offset;
                 let bytes = if remaining == last_block_size {
                     last_block_size
@@ -164,7 +162,17 @@ pub fn decompress_with_limit(
                 bits_consumed += bytes * 8;
             }
             Header::Arity(_) => {
-                return Err(TelomereError::Header("compressed spans unsupported".into()));
+                let mut reader = BitReader::from_slice(slice);
+                let span = decode_span(&mut reader, config)
+                    .map_err(|_| TelomereError::Header("orphan/truncated bits".into()))?;
+                let span_bits = reader.bits_read();
+                let bytes = span.len();
+                if out.len() + bytes > limit {
+                    return Err(TelomereError::Header("invalid header field".into()));
+                }
+                out.extend_from_slice(&span);
+                offset += (span_bits + 7) / 8;
+                bits_consumed += ((span_bits + 7) / 8) * 8;
             }
         }
         if offset == input.len() {

--- a/tests/decompress_spans.rs
+++ b/tests/decompress_spans.rs
@@ -1,0 +1,104 @@
+use telomere::{
+    decompress_with_limit, encode_arity_bits, encode_evql_bits, encode_header, encode_tlmr_header,
+    truncated_hash, Config, Header,
+};
+
+fn cfg(block: usize) -> Config {
+    Config {
+        block_size: block,
+        hash_bits: 13,
+        ..Config::default()
+    }
+}
+
+fn pack_bits(bits: &[bool]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut byte = 0u8;
+    let mut used = 0u8;
+    for &b in bits {
+        byte = (byte << 1) | b as u8;
+        used += 1;
+        if used == 8 {
+            out.push(byte);
+            byte = 0;
+            used = 0;
+        }
+    }
+    if used > 0 {
+        byte <<= 8 - used;
+        out.push(byte);
+    }
+    if out.is_empty() {
+        out.push(0);
+    }
+    out
+}
+
+#[test]
+fn bundled_span_roundtrip() {
+    let block_size = 3usize;
+    let seed_block = [0xAAu8, 0xBB, 0xCC];
+    let mut config = cfg(block_size);
+    config.seed_expansions.insert(0, {
+        let mut b = Vec::new();
+        for _ in 0..3 {
+            b.extend_from_slice(&encode_header(&Header::Literal).unwrap());
+            b.extend_from_slice(&seed_block);
+        }
+        b
+    });
+
+    let mut bits = encode_arity_bits(3).unwrap();
+    bits.extend(encode_evql_bits(0));
+    let body = pack_bits(&bits);
+
+    let mut data = encode_tlmr_header(&telomere::TlmrHeader {
+        version: 0,
+        block_size,
+        last_block_size: block_size,
+        output_hash: truncated_hash(&seed_block.repeat(3)),
+    })
+    .to_vec();
+    data.extend_from_slice(&body);
+
+    let out = decompress_with_limit(&data, &config, usize::MAX).unwrap();
+    assert_eq!(out, seed_block.repeat(3));
+}
+
+#[test]
+fn bundled_then_literal() {
+    let block_size = 3usize;
+    let seed_block = [0x10u8, 0x20, 0x30];
+    let tail = [0x40u8, 0x50, 0x60];
+    let mut config = cfg(block_size);
+    config.seed_expansions.insert(0, {
+        let mut b = Vec::new();
+        for _ in 0..3 {
+            b.extend_from_slice(&encode_header(&Header::Literal).unwrap());
+            b.extend_from_slice(&seed_block);
+        }
+        b
+    });
+
+    let mut bits = encode_arity_bits(3).unwrap();
+    bits.extend(encode_evql_bits(0));
+    let span = pack_bits(&bits);
+
+    let mut body = span.clone();
+    body.extend_from_slice(&encode_header(&Header::Literal).unwrap());
+    body.extend_from_slice(&tail);
+
+    let mut data = encode_tlmr_header(&telomere::TlmrHeader {
+        version: 0,
+        block_size,
+        last_block_size: block_size,
+        output_hash: truncated_hash(&[seed_block.repeat(3), tail.to_vec()].concat()),
+    })
+    .to_vec();
+    data.extend_from_slice(&body);
+
+    let out = decompress_with_limit(&data, &config, usize::MAX).unwrap();
+    let mut expected = seed_block.repeat(3);
+    expected.extend_from_slice(&tail);
+    assert_eq!(out, expected);
+}


### PR DESCRIPTION
## Summary
- support decoding arity spans by recursively expanding seeds
- add tests for bundled spans
- whitelist new test in `.gitignore`

## Testing
- `cargo test --test decompress_spans --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687daf11c2348329bfe950b86de87edc