### PR TITLE
Add optional XXHash-based seed hashing

### DIFF
--- a/src/block_indexer.rs
+++ b/src/block_indexer.rs
@@ -28,6 +28,7 @@ pub fn brute_force_seed_tables(
     data: &[u8],
     max_block_size: usize,
     max_seed_len: usize,
+    use_xxhash: bool,
 ) -> Result<HashMap<usize, Vec<IndexedBlock>>, TelomereError> {
     let mut tables: HashMap<usize, Vec<IndexedBlock>> = HashMap::new();
     let mut limit: u128 = 0;
@@ -44,7 +45,7 @@ pub fn brute_force_seed_tables(
             let mut matches = Vec::new();
             for s_idx in 0..limit {
                 let seed = index_to_seed(s_idx as usize, max_seed_len)?;
-                if expand_seed(&seed, slice.len()) == slice {
+                if expand_seed(&seed, slice.len(), use_xxhash) == slice {
                     matches.push(s_idx as usize);
                 }
             }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -69,7 +69,8 @@ pub fn compress_with_config(data: &[u8], config: &Config) -> Result<Vec<u8>, Tel
             }
             let span_len = arity * block_size;
             let slice = &data[offset..offset + span_len];
-            if let Some(seed_idx) = find_seed_match(slice, config.max_seed_len)? {
+            if let Some(seed_idx) = find_seed_match(slice, config.max_seed_len, config.use_xxhash)?
+            {
                 let header_bits = encode_arity_bits(arity)?;
                 let evql_bits = encode_evql_bits(seed_idx);
                 let total_bits = header_bits.len() + evql_bits.len();
@@ -173,7 +174,9 @@ pub fn compress_multi_pass_with_config(
                     break;
                 }
                 let span = &current[span_start..span_end];
-                if let Some(seed_idx) = find_seed_match(span, config.max_seed_len)? {
+                if let Some(seed_idx) =
+                    find_seed_match(span, config.max_seed_len, config.use_xxhash)?
+                {
                     let header_bits = encode_arity_bits(arity)?;
                     let evql_bits = encode_evql_bits(seed_idx);
                     let total_bits = header_bits.len() + evql_bits.len();
@@ -265,7 +268,7 @@ pub fn compress_block_with_config(
     }
 
     let slice = &input[..block_size];
-    if let Some(seed_idx) = find_seed_match(slice, config.max_seed_len)? {
+    if let Some(seed_idx) = find_seed_match(slice, config.max_seed_len, config.use_xxhash)? {
         let header_bits = encode_arity_bits(1)?;
         let evql_bits = encode_evql_bits(seed_idx);
         let total_bits = header_bits.len() + evql_bits.len();

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub max_arity: u8,
     /// Number of bits used when truncating seed hashes.
     pub hash_bits: usize,
+    /// If true, use a fast XXHash-like hash for seed expansion; otherwise use SHA-256.
+    pub use_xxhash: bool,
     /// Pre-expanded seed bitstreams indexed by seed index.
     pub seed_expansions: HashMap<usize, Vec<u8>>,
 }
@@ -26,6 +28,7 @@ impl Default for Config {
             max_seed_len: 0,
             max_arity: 0,
             hash_bits: 0,
+            use_xxhash: false,
             seed_expansions: HashMap::new(),
         }
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -291,7 +291,11 @@ fn decode_span_rec(
             let seed_idx = decode_evql_bits(reader)?;
             reader.align_byte();
             let seed = crate::index_to_seed(seed_idx, config.max_seed_len)?;
-            Ok(crate::expand_seed(&seed, arity * config.block_size))
+            Ok(crate::expand_seed(
+                &seed,
+                arity * config.block_size,
+                config.use_xxhash,
+            ))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn run() -> Result<(), CliError> {
                 max_seed_len: args.max_seed_len,
                 max_arity: args.max_arity,
                 hash_bits: args.hash_bits,
+                use_xxhash: false,
                 seed_expansions: std::collections::HashMap::new(),
             };
             let data = fs::read(&input_path)
@@ -126,6 +127,7 @@ fn run() -> Result<(), CliError> {
                 max_seed_len: args.max_seed_len,
                 max_arity: args.max_arity,
                 hash_bits: args.hash_bits,
+                use_xxhash: false,
                 seed_expansions: std::collections::HashMap::new(),
             };
             if input_path

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -1,17 +1,38 @@
 //! See [Kolyma Spec](../kolyma.pdf) - 2025-07-20 - commit c48b123cf3a8761a15713b9bf18697061ab23976
 use crate::{index_to_seed, TelomereError};
-use sha2::{Digest, Sha256};
+use sha2::Digest;
+
+/// Return a 32-byte digest of `input` using either SHA-256 or a simple XXHash-like algorithm.
+pub fn digest32(input: &[u8], use_xxhash: bool) -> [u8; 32] {
+    if use_xxhash {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for &b in input {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        let mut out = [0u8; 32];
+        for i in 0..4 {
+            out[i * 8..(i + 1) * 8].copy_from_slice(&h.to_le_bytes());
+            h = h
+                .rotate_left(13)
+                .wrapping_add(i as u64 + 0x9e3779b97f4a7c15);
+        }
+        out
+    } else {
+        sha2::Sha256::digest(input).into()
+    }
+}
 
 /// Expand `seed` to exactly `len` bytes by repeatedly hashing with SHA-256.
 ///
 /// The expansion starts with the seed bytes themselves. The SHA-256 digest of
 /// the current buffer is appended repeatedly until at least `len` bytes have
 /// been produced. The resulting vector is truncated to `len`.
-pub fn expand_seed(seed: &[u8], len: usize) -> Vec<u8> {
+pub fn expand_seed(seed: &[u8], len: usize, use_xxhash: bool) -> Vec<u8> {
     let mut out = Vec::with_capacity(len);
     let mut cur = seed.to_vec();
     while out.len() < len {
-        let digest: [u8; 32] = Sha256::digest(&cur).into();
+        let digest = digest32(&cur, use_xxhash);
         out.extend_from_slice(&digest);
         cur = digest.to_vec();
     }
@@ -25,14 +46,18 @@ pub fn expand_seed(seed: &[u8], len: usize) -> Vec<u8> {
 /// Seeds are enumerated according to [`index_to_seed`] up to
 /// `max_seed_len`. The first matching index is returned if any. Matching is
 /// deterministic and greedy over enumeration order.
-pub fn find_seed_match(slice: &[u8], max_seed_len: usize) -> Result<Option<usize>, TelomereError> {
+pub fn find_seed_match(
+    slice: &[u8],
+    max_seed_len: usize,
+    use_xxhash: bool,
+) -> Result<Option<usize>, TelomereError> {
     let mut limit: u128 = 0;
     for len in 1..=max_seed_len {
         limit += 1u128 << (8 * len);
     }
     for idx in 0..limit {
         let seed = index_to_seed(idx as usize, max_seed_len)?;
-        if expand_seed(&seed, slice.len()) == slice {
+        if expand_seed(&seed, slice.len(), use_xxhash) == slice {
             return Ok(Some(idx as usize));
         }
     }

--- a/src/sha_cache.rs
+++ b/src/sha_cache.rs
@@ -4,16 +4,19 @@
 //! recently used value when full.  It can also persist and reload a hash
 //! table from disk for testing purposes.
 
+use crate::seed::digest32;
 use bincode;
-use sha2::{Digest, Sha256};
+use sha2::Digest;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read};
 
+type CacheKey = (bool, Vec<u8>);
+
 pub struct ShaCache {
     capacity: usize,
-    map: HashMap<Vec<u8>, [u8; 32]>,
-    order: Vec<Vec<u8>>, // simple queue for LRU
+    map: HashMap<CacheKey, [u8; 32]>,
+    order: Vec<CacheKey>, // simple queue for LRU
 }
 
 impl ShaCache {
@@ -27,14 +30,14 @@ impl ShaCache {
         }
     }
 
-    fn touch(&mut self, key: &[u8]) {
-        if let Some(pos) = self.order.iter().position(|k| k.as_slice() == key) {
+    fn touch(&mut self, key: &CacheKey) {
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
             let key_vec = self.order.remove(pos);
             self.order.push(key_vec);
         }
     }
 
-    fn insert(&mut self, key: Vec<u8>, value: [u8; 32]) {
+    fn insert(&mut self, key: CacheKey, value: [u8; 32]) {
         if self.map.len() >= self.capacity {
             if let Some(old) = self.order.first() {
                 self.map.remove(old);
@@ -47,15 +50,15 @@ impl ShaCache {
         self.map.insert(key, value);
     }
 
-    pub fn get_or_compute(&mut self, seed: &[u8]) -> [u8; 32] {
-        let value = self.map.get(seed).cloned();
+    pub fn get_or_compute(&mut self, seed: &[u8], use_xxhash: bool) -> [u8; 32] {
+        let key: CacheKey = (use_xxhash, seed.to_vec());
+        let value = self.map.get(&key).cloned();
         if let Some(v) = value {
-            self.touch(seed);
+            self.touch(&key);
             v
         } else {
-            let digest = Sha256::digest(seed);
-            let arr: [u8; 32] = digest.into();
-            self.insert(seed.to_vec(), arr);
+            let arr = digest32(seed, use_xxhash);
+            self.insert(key, arr);
             arr
         }
     }
@@ -65,8 +68,11 @@ pub fn load_hash_table(path: &str) -> Result<HashMap<Vec<u8>, [u8; 32]>, crate::
     let file = File::open(path).map_err(crate::TelomereError::from)?;
     let mut reader = BufReader::new(file);
     let mut buf = Vec::new();
-    reader.read_to_end(&mut buf).map_err(crate::TelomereError::from)?;
-    let table: HashMap<Vec<u8>, [u8; 32]> = bincode::deserialize(&buf)
-        .map_err(|e| crate::TelomereError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
+    reader
+        .read_to_end(&mut buf)
+        .map_err(crate::TelomereError::from)?;
+    let table: HashMap<Vec<u8>, [u8; 32]> = bincode::deserialize(&buf).map_err(|e| {
+        crate::TelomereError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    })?;
     Ok(table)
 }

--- a/tests/brute_force_index.rs
+++ b/tests/brute_force_index.rs
@@ -5,7 +5,7 @@ use telomere::brute_force_seed_tables;
 fn seed_zero_matches_across_block_sizes() {
     // SHA-256 of seed 0 starts with 6e 34 0b
     let data = [0x6e, 0x34, 0x0b];
-    let tables = brute_force_seed_tables(&data, 3, 1).expect("indexing");
+    let tables = brute_force_seed_tables(&data, 3, 1, false).expect("indexing");
     // block size 1: three blocks
     let bs1 = tables.get(&1).unwrap();
     assert_eq!(bs1.len(), 3);
@@ -23,7 +23,7 @@ fn seed_zero_matches_across_block_sizes() {
 #[test]
 fn final_partial_block_included() {
     let data = [1u8, 2, 3, 4];
-    let tables = brute_force_seed_tables(&data, 3, 1).expect("indexing");
+    let tables = brute_force_seed_tables(&data, 3, 1, false).expect("indexing");
     // for block size 3 there should be two entries, second is partial len 1
     let bs3 = tables.get(&3).unwrap();
     assert_eq!(bs3.len(), 2);

--- a/tests/compress_multi_pass.rs
+++ b/tests/compress_multi_pass.rs
@@ -4,7 +4,7 @@ use telomere::{compress, compress_multi_pass, expand_seed};
 #[test]
 fn multi_pass_converges_without_gain() {
     let block = 3usize;
-    let data = expand_seed(&[0u8], block * 3);
+    let data = expand_seed(&[0u8], block * 3, false);
     let single = compress(&data, block).unwrap();
     let (multi, gains) = compress_multi_pass(&data, block, 5, false).unwrap();
     assert_eq!(single, multi);
@@ -14,7 +14,7 @@ fn multi_pass_converges_without_gain() {
 #[test]
 fn random_input_never_grows() {
     let block = 3usize;
-    let mut data = expand_seed(&[2u8], block * 2);
+    let mut data = expand_seed(&[2u8], block * 2, false);
     data.extend_from_slice(&[1, 2, 3]);
     let single = compress(&data, block).unwrap();
     let (multi, gains) = compress_multi_pass(&data, block, 3, false).unwrap();
@@ -25,8 +25,8 @@ fn random_input_never_grows() {
 #[test]
 fn repeated_seeds_gain_over_single_pass() {
     let block = 3usize;
-    let mut data = expand_seed(&[1u8], block * 2);
-    data.extend_from_slice(&expand_seed(&[1u8], block * 2));
+    let mut data = expand_seed(&[1u8], block * 2, false);
+    data.extend_from_slice(&expand_seed(&[1u8], block * 2, false));
     let single = compress(&data, block).unwrap();
     let (multi, gains) = compress_multi_pass(&data, block, 3, false).unwrap();
     assert!(multi.len() <= single.len());

--- a/tests/compress_seeds.rs
+++ b/tests/compress_seeds.rs
@@ -5,9 +5,14 @@ use telomere::{compress, decompress_with_limit, expand_seed, Config};
 fn compress_seeds_roundtrip() {
     let block_size = 3usize;
     let seed = vec![0u8];
-    let data = expand_seed(&seed, block_size * 4);
+    let data = expand_seed(&seed, block_size * 4, false);
     let compressed = compress(&data, block_size).unwrap();
-    let cfg = Config { block_size, max_seed_len: 3, hash_bits: 13, ..Config::default() };
+    let cfg = Config {
+        block_size,
+        max_seed_len: 3,
+        hash_bits: 13,
+        ..Config::default()
+    };
     let decompressed = decompress_with_limit(&compressed, &cfg, usize::MAX).unwrap();
     assert_eq!(decompressed, data);
 }

--- a/tests/decode_arity_blocks.rs
+++ b/tests/decode_arity_blocks.rs
@@ -70,7 +70,7 @@ fn decode_seed_arity_stream() {
     let mut config = Config::default();
     config.block_size = 3;
     config.max_seed_len = 1;
-    let block = telomere::expand_seed(&[0u8], config.block_size);
+    let block = telomere::expand_seed(&[0u8], config.block_size, false);
 
     let mut bits = encode_arity(1);
     bits.extend(encode_evql_bits(0));

--- a/tests/decompress_seeds.rs
+++ b/tests/decompress_seeds.rs
@@ -1,7 +1,12 @@
-use telomere::{compress, decompress_with_limit, index_to_seed, expand_seed, Config};
+use telomere::{compress, decompress_with_limit, expand_seed, index_to_seed, Config};
 
 fn cfg(bs: usize, max_seed_len: usize) -> Config {
-    Config { block_size: bs, max_seed_len, hash_bits: 13, ..Config::default() }
+    Config {
+        block_size: bs,
+        max_seed_len,
+        hash_bits: 13,
+        ..Config::default()
+    }
 }
 
 #[test]
@@ -10,7 +15,7 @@ fn seed_indices_roundtrip() {
     let cfg = cfg(block, 3);
     for idx in 0..10usize {
         let seed = index_to_seed(idx, cfg.max_seed_len).unwrap();
-        let data = expand_seed(&seed, block);
+        let data = expand_seed(&seed, block, false);
         let compressed = compress(&data, block).unwrap();
         let out = decompress_with_limit(&compressed, &cfg, usize::MAX).unwrap();
         assert_eq!(out, data);

--- a/tests/nested_decode.rs
+++ b/tests/nested_decode.rs
@@ -77,7 +77,7 @@ fn nested_seed_decode() {
         pack_bits(&bits)
     };
 
-    let expected = telomere::expand_seed(&[0u8], config.block_size);
+    let expected = telomere::expand_seed(&[0u8], config.block_size, false);
     let mut reader = BitReader::from_slice(&stream);
     let out = decode_span(&mut reader, &config).unwrap();
     assert_eq!(out, expected);

--- a/tests/seed_match_properties.rs
+++ b/tests/seed_match_properties.rs
@@ -8,8 +8,8 @@ quickcheck! {
     fn roundtrip_matches(seed: Vec<u8>, len: u8) -> bool {
         if seed.is_empty() || seed.len() > MAX_LEN { return true; }
         let span = (len % 16 + 1) as usize;
-        let data = expand_seed(&seed, span);
-        match find_seed_match(&data, MAX_LEN).ok().flatten() {
+        let data = expand_seed(&seed, span, false);
+        match find_seed_match(&data, MAX_LEN, false).ok().flatten() {
             Some(idx) => index_to_seed(idx, MAX_LEN).unwrap() == seed,
             None => false,
         }
@@ -18,9 +18,9 @@ quickcheck! {
 
 quickcheck! {
     fn unmatched_returns_none(data: Vec<u8>) -> bool {
-        if let Ok(Some(idx)) = find_seed_match(&data, MAX_LEN) {
+        if let Ok(Some(idx)) = find_seed_match(&data, MAX_LEN, false) {
             let seed = index_to_seed(idx, MAX_LEN).unwrap();
-            expand_seed(&seed, data.len()) == data
+            expand_seed(&seed, data.len(), false) == data
         } else {
             true
         }


### PR DESCRIPTION
## Summary
- add `use_xxhash` option to `Config`
- support XXHash-like hashing in `seed::digest32` and seed expansion
- thread the flag through seed search, compression and decoding
- update `ShaCache` to use the selected digest
- adjust CLI defaults and block indexer utility
- update tests for new `expand_seed` signature

## Testing
- `cargo test --lib --quiet`
- `cargo test --test compress_seeds --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6882dab73d5c8329854e7762d86ff2e7